### PR TITLE
Disabled the empty drop-down list

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -102,6 +102,7 @@ never=Never
 months=Months
 openid_provider_label=OpenID provider label
 openid_provider=OpenID provider
+no_options_available =No options available
 allow_users_to_grant_own_user_roles=Allow users to grant own user roles
 object_not_deleted_associated_by_objects=Object not deleted because it is associated by objects of type
 analytics_max_limit=Maximum number of analytics records

--- a/src/app.component.js
+++ b/src/app.component.js
@@ -142,23 +142,40 @@ export default React.createClass({
                         }),
                     });
 
-                case 'dropdown':
-                    return Object.assign({}, fieldBase, {
+                case 'dropdown': {
+                    const dropDownFieldBase = fieldBase;
+                    const defaultEmptyLabel = 'no_options_available';
+                    // If there are no options and no source, placeholder text should show emptyLabel
+                    if (!mapping.options && !mapping.source) {
+                        dropDownFieldBase.props.floatingLabelText = mapping.emptyLabel ? this.props.d2.i18n.getTranslation(mapping.emptyLabel) : this.props.d2.i18n.getTranslation(defaultEmptyLabel);
+                    }
+                    if (mapping.source) {
+                        const items = configOptionStore.state && configOptionStore.state[mapping.source] || [];
+                        // If items is a ModelCollection
+                        if (typeof items.size !== 'undefined') {
+                            if (items.size === 0) {
+                                dropDownFieldBase.props.floatingLabelText = mapping.emptyLabel ? this.props.d2.i18n.getTranslation(mapping.emptyLabel) : this.props.d2.i18n.getTranslation(defaultEmptyLabel);
+                            }
+                        } else {
+                            // If items is an Array
+                            if (items.length === 0) {
+                                dropDownFieldBase.props.floatingLabelText = mapping.emptyLabel ? this.props.d2.i18n.getTranslation(mapping.emptyLabel) : this.props.d2.i18n.getTranslation(defaultEmptyLabel);
+                            }
+                        }
+                    }
+                    return Object.assign({}, dropDownFieldBase, {
                         component: HackyDropDown,
                         props: Object.assign({}, fieldBase.props, {
-                            menuItems: mapping.source ?
-                            configOptionStore.state && configOptionStore.state[mapping.source] || [] :
+                            menuItems: mapping.source ? configOptionStore.state && configOptionStore.state[mapping.source] || [] :
                                 Object.keys(mapping.options).map(id => {
                                     const displayName = !isNaN(mapping.options[id]) ?
                                         mapping.options[id] :
                                         this.props.d2.i18n.getTranslation(mapping.options[id]);
                                     return { id, displayName };
                                 }),
-                            includeEmpty: !!mapping.includeEmpty,
-                            emptyLabel: !!mapping.includeEmpty && mapping.emptyLabel ?
-                                this.props.d2.i18n.getTranslation(mapping.emptyLabel) : '',
                         }),
                     });
+                }
 
                 case 'checkbox':
                     return Object.assign({}, fieldBase, {

--- a/src/form-fields/drop-down.js
+++ b/src/form-fields/drop-down.js
@@ -52,13 +52,18 @@ export default React.createClass({
         }
     },
 
+    isDisabled(menuItems) {
+        return menuItems.length > 0 ? false : true; 
+    },
+
     render() {
         const {onFocus, onBlur, onChange, menuItems, ...other} = this.props;
         return (
             <SelectField
                 value={this.props.value}
                 onChange={this.handleChange}
-                {...other}>
+                {...other}
+                disabled={this.isDisabled(Array.isArray(menuItems) ? menuItems : menuItems.toArray())}>
                 {this.renderMenuItems(Array.isArray(menuItems) ? menuItems : menuItems.toArray())}
             </SelectField>
         );

--- a/src/form-fields/drop-down.js
+++ b/src/form-fields/drop-down.js
@@ -19,36 +19,17 @@ export default React.createClass({
             React.PropTypes.array,
             React.PropTypes.object,
         ]),
-        includeEmpty: React.PropTypes.bool,
-        emptyLabel: React.PropTypes.string,
     },
 
     mixins: [MuiThemeMixin],
 
-    getDefaultProps() {
-        return {
-            includeEmpty: false,
-            emptyLabel: '',
-        };
-    },
-
     renderMenuItems(menuItems) {
-        if (this.props.includeEmpty) {
-            menuItems.unshift(menuItems.length > 0 && !!menuItems[0].id ? {id: 'null', displayName: this.props.emptyLabel} : {payload: 'null', text: this.props.emptyLabel});
-        }
-
         if (!!menuItems) {
             return menuItems.map(item => {
                 return !!item.id ?
                     (<MenuItem key={item.id} value={item.id} primaryText={item.displayName} />) :
                     (<MenuItem key={item.payload} value={item.payload} primaryText={item.text} />);
             });
-        }
-    },
-
-    renderEmptyItem() {
-        if (this.props.includeEmpty) {
-            return <MenuItem value="null" primaryText={this.props.emptyLabel}/>;
         }
     },
 


### PR DESCRIPTION
Fix for https://github.com/dhis2/settings-app/issues/39

NOTE: In all cases, the placeholder is emptyLabel taken from settingsKeyMapping. If emptyLabel is not defined, i have included a default emptyLabel = "no_options_available".

Cases:
1. If there are no options and no source - disable the dropdown and show emptyLabel as placeholder
2. If there is a source, if configOptionStore.state[mapping.source] is either a ModelCollection with size equals zero or it is an Array with length equals zero - disable the dropdown and show emptyLabel
3. If none of the above two conditions, then placeholder should be the 'label' from  settingsKeyMapping file.

@nicolayr Please let me know if i have missed something.