### PR TITLE
addressing issue 14: https://github.com/dhis2/settings-app/issues/14

### DIFF
--- a/src/form-fields/file-upload.js
+++ b/src/form-fields/file-upload.js
@@ -58,6 +58,10 @@ export default React.createClass({
             overflow: 'auto',
             padding: 48,
         };
+        const dialogImgStyle = {
+          maxWidth: '100%',
+          maxHeight: '70vh',
+        };
 
         const apiBase = this.context.d2.Api.getApi().baseUrl;
         const imgUrl = [apiBase, 'staticContent', this.props.name].join('/') + '?at=' + new Date();
@@ -73,7 +77,7 @@ export default React.createClass({
                             autoDetectWindowHeight
                             autoScrollBodyContent
                             bodyStyle={bodyStyle}>
-                        <img src={imgUrl} />
+                        <img style={dialogImgStyle} src={imgUrl} />
                     </Dialog>
                 </div>
             );


### PR DESCRIPTION
Issue 14: https://github.com/dhis2/settings-app/issues/14

I added a simple style object that gets set as the style for the img inside the Dialog component. I was not sure if you guys like to do styles via JavaScript, but it looks like you already did the same for the `bodyStyle`. Also followed the dangling comma convention.

It should at least handle the following two cases:

1. Large overflowing horizontal image:
![image](https://cloud.githubusercontent.com/assets/8015228/13715186/2ee26fa0-e7a1-11e5-922c-f9ce01ef371b.png)

2. Large overflowing vertical image:
![image](https://cloud.githubusercontent.com/assets/8015228/13715177/275adc04-e7a1-11e5-9b90-9adb8672e228.png)
