### PR TITLE
Dhis2 2785/cannot edit oauth2 clients

### DIFF
--- a/src/oauth2-client-editor/OAuth2ClientEditor.component.js
+++ b/src/oauth2-client-editor/OAuth2ClientEditor.component.js
@@ -91,12 +91,7 @@ export default React.createClass({
     },
 
     editAction(model) {
-        // Cast model to JSON so properties can be deleted
-        const modelJSON = model.toJSON();
-        // Remove the favorite property, since this doesn't have a setter on the model
-        // ... and it is not needed to display the edit-form and save the model
-        delete modelJSON.favorite;
-        this.clientModel = Object.assign(this.context.d2.models.oAuth2Client.create(), model);
+        this.clientModel = model;
         this.setState({ showForm: true });
     },
 

--- a/src/oauth2-client-editor/OAuth2ClientEditor.component.js
+++ b/src/oauth2-client-editor/OAuth2ClientEditor.component.js
@@ -91,6 +91,11 @@ export default React.createClass({
     },
 
     editAction(model) {
+        // Cast model to JSON so properties can be deleted
+        const modelJSON = model.toJSON();
+        // Remove the favorite property, since this doesn't have a setter on the model
+        // ... and it is not needed to display the edit-form and save the model
+        delete modelJSON.favorite;
         this.clientModel = Object.assign(this.context.d2.models.oAuth2Client.create(), model);
         this.setState({ showForm: true });
     },


### PR DESCRIPTION
Fixes bug that prevented the edit OAuth clients to be edited
- The problem was that when setting `this.clientModel` was created, Object.assign would try to set the `favorite` property on the newly created model instance, but this property is non-writable.
- Instead, the incoming model is used directly by the edit form, which makes more sense conceptually as well.

NB: I didn't request any reviewers on this PR because I already discussed the solution with @varl during a call.