### PR TITLE
set includeEmpty: false

### DIFF
--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -291,6 +291,7 @@ const settingsKeyMapping = {
     keyStyle: {
         label: 'style',
         type: 'dropdown',
+        includeEmpty: false,
         userSettingsOverride: true,
         searchLabels: ['style', 'can_be_overridden_by_user_settings'],
         source: 'styles',


### PR DESCRIPTION
setting **includeEmpty: false** will prevent null being set to keyStyle.