### PR TITLE
Show snackbar horizontally centered instead of off-canvas

### DIFF
--- a/src/app.component.js
+++ b/src/app.component.js
@@ -147,7 +147,6 @@ class AppComponent extends React.Component {
                         autoHideDuration={1250}
                         open={this.state.showSnackbar}
                         onRequestClose={this.closeSnackbar}
-                        style={{ left: 24, right: 'inherit' }}
                     />
                     <Sidebar
                         sections={sections}


### PR DESCRIPTION
I think that the inline styles that were there previously used to work with an older version of Material UI. In the current version they don't and I think showing the snackbar in the center is fine, so I just removed these styles.