### PR TITLE
fix: messaging-section

### DIFF
--- a/src/form-fields/check-box.js
+++ b/src/form-fields/check-box.js
@@ -2,11 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Checkbox from 'material-ui/Checkbox';
 
-const CheckBox = ({ errorText, errorStyle, onChange, value, ...other }) => (
-    <div style={{ marginTop: 12, marginBottom: 12 }}>
-        <Checkbox onCheck={onChange} checked={value === 'true'} {...other} />
-    </div>
-);
+/* eslint-disable react/prefer-stateless-function */
+class CheckBox extends React.Component {
+    render() {
+        const { errorText, errorStyle, onChange, value, ...other } = this.props
+        return (
+            <div style={{ marginTop: 12, marginBottom: 12 }}>
+                <Checkbox onCheck={onChange} checked={value === 'true'} {...other} />
+            </div>
+        )
+    }
+}
+/* eslint-enable */
 
 CheckBox.propTypes = {
     onChange: PropTypes.func.isRequired,


### PR DESCRIPTION

- After refactoring the CheckBox to a stateless function, the messaging section broke
- It all went wrong here, because you can't extend a function https://github.com/dhis2/settings-app/blob/76dbda97e583f18713f4e3f3c5ce936e59103c02/src/settingsFields.component.js#L66
- To fix it, for now, I've just rewrote the CheckBox as a class again.

I don't see this as a proper solution, it's just a quick fix that has very little chance of breaking other stuff.

The proper solution would be to stop using inheritance and refactor `wrapUserSettingsOverride` to a HOC or something. But really, when you look at that whole file `src/settingsFields.component.js`, it's way too big and complex. So instead I have made a new JIRA issue for refactoring the app a bit: https://jira.dhis2.org/browse/DHIS2-6537