### PR TITLE
fix: appearance-settings

### DIFF
--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -33,8 +33,8 @@ class LocalizedTextEditor extends React.Component {
         super(props, context);
 
         this.state = {
-            locale: context.d2.system.settings.settings.keyUiLocale,
-            localeName: LocalizedTextEditor.getLocaleName(context.d2.system.settings.settings.keyUiLocale),
+            locale: settingsStore.state.keyUiLocale,
+            localeName: LocalizedTextEditor.getLocaleName(settingsStore.state.keyUiLocale),
         };
 
         this.handleChange = this.handleChange.bind(this);


### PR DESCRIPTION
Now reading keyUiLocale from settingStore instead of d2.system.settings, because settingsStore is not cleared