### PR TITLE
feat(checkbox): add sectionLabel prop to checkbox (DHIS2-6842)

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -231,6 +231,7 @@ enable_message_email_notifications=Enable message email notifications
 enable_message_sms_notifications=Enable message SMS notifications
 can_be_overridden_by_user_settings=This setting can be overridden by user settings
 will_be_overridden_by_current_user_setting=This setting will be overridden by the current user setting
+hidden_period_types_in_analytics_apps=Hidden period types in analytics apps
 keyStopMetadataSync=Don't sync metadata if DHIS versions differ
 keyVersionEnabled=Enable Versioning for metadata sync
 create_metadata_version=Create new version

--- a/src/form-fields/check-box.js
+++ b/src/form-fields/check-box.js
@@ -2,12 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Checkbox from 'material-ui/Checkbox';
 
+const sectionLabelStyle = {
+    color: 'rgba(0, 0, 0, 0.3)',
+    fontSize: '12px',
+    margin: '16px 0 6px 0',
+}
+
 /* eslint-disable react/prefer-stateless-function */
 class CheckBox extends React.Component {
     render() {
-        const { errorText, errorStyle, onChange, value, ...other } = this.props
+        const { errorText, errorStyle, onChange, sectionLabel, value, ...other } = this.props
+
         return (
             <div style={{ marginTop: 12, marginBottom: 12 }}>
+                {sectionLabel && <p style={sectionLabelStyle}>{sectionLabel}</p>}
                 <Checkbox onCheck={onChange} checked={value === 'true'} {...other} />
             </div>
         )
@@ -19,6 +27,7 @@ CheckBox.propTypes = {
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
     errorText: PropTypes.string,
+    sectionLabel: PropTypes.string,
     errorStyle: PropTypes.object,
 
 };
@@ -27,6 +36,7 @@ CheckBox.defaultProps = {
     value: 'false',
     errorText: undefined,
     errorStyle: undefined,
+    sectionLabel: undefined,
 };
 
 export default CheckBox;

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -196,6 +196,7 @@ class SettingsFields extends React.Component {
                         component: Checkbox,
                         props: {
                             label: fieldBase.props.floatingLabelText,
+                            sectionLabel: (mapping.sectionLabel && d2.i18n.getTranslation(mapping.sectionLabel) ) || undefined,
                             style: fieldBase.props.style,
                             onCheck: (e, v) => {
                                 settingsActions.saveKey(key, v ? 'true' : 'false');

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -160,6 +160,7 @@ const settingsKeyMapping = {
     },
     keyHideDailyPeriods: {
         label: 'key_hide_daily_periods',
+        sectionLabel: 'hidden_period_types_in_analytics_apps',
         type: 'checkbox',
     },
     keyHideWeeklyPeriods: {


### PR DESCRIPTION
I initially tried adding separate `SectionLabel` component, because that seemed like the most elegant solution. My idea was to then add an arbitrary object to the `src/settingsKeyMapping.js`, just above the first item in that section: `keyHideDailyPeriods `.

But unfortunately that approach wouldn't work for two reasons:
- `src/settingsFields.component.js` loops through the setting-keys returned from the server, not the ones defined in `src/settingsKeyMapping.js`, so it would simply skip it.
- Since `settingsKeyMapping` is an object, not an array, we'd have to give every new `SectionLabel` a unique key, which would make things pretty confusing.

So in the end I went for the easiest solution: just render a section label above the checkbox, if a `sectionLabel` prop has been provided. This was the simplest solution, but this does mean that we can only show section-labels above checkboxes. Other input components will require additional work if it turns out they need section-labels too.

If you have a better solution that doesn't require us to do a big refactor, I am all ears.