### PR TITLE
fix(oauth-client): enable editing (DHIS2-7588)

### DIFF
--- a/src/oauth2-client-editor/OAuth2ClientEditor.component.js
+++ b/src/oauth2-client-editor/OAuth2ClientEditor.component.js
@@ -45,6 +45,7 @@ class OAuth2ClientEditor extends React.Component {
         super(props);
 
         this.formUpdateAction = this.formUpdateAction.bind(this);
+        this.editAction = this.editAction.bind(this);
         this.saveAction = this.saveAction.bind(this);
         this.deleteAction = this.deleteAction.bind(this);
         this.cancelAction = this.cancelAction.bind(this);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,6 @@ try {
  */
 
 function bypass(req, res, opt) {
-    req.headers.Authorization = dhisConfig.authorization;
     console.log('[PROXY]', req.method, req.url, '=>', opt.target);
 }
 


### PR DESCRIPTION
The problem here was that the editAction method had not been bound to the component instance and as a result `this.setState` was not available in the function.

I had a problem running this app locally. All proxied requests were trying to set authorisation headers and this was breaking the session. So I removed that part. This will mean that you can only run this app in development mode after you have logged in to your local dhis2-core instance. I don't think this is a problem, because that's what most of our apps do.

I will also have to backport this to v32 and v33.