### PR TITLE
fix(forms): prevent autocomplete on form, username and password fields

### DIFF
--- a/src/app.component.js
+++ b/src/app.component.js
@@ -151,8 +151,9 @@ class AppComponent extends React.Component {
                         onChangeSearchText={this.doSearch}
                         searchText={this.state.searchText}
                     />
-
-                    <SettingsFields category={this.state.category} currentSettings={this.state.currentSettings} />
+                    <form autoComplete="off">
+                        <SettingsFields category={this.state.category} currentSettings={this.state.currentSettings} />
+                    </form>
                 </div>
             </MuiThemeProvider>
         );

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -155,7 +155,6 @@ class SettingsFields extends React.Component {
                         props: Object.assign({}, fieldBase.props, {
                             changeEvent: 'onBlur',
                             multiLine: !!mapping.multiLine,
-                            autoComplete: mapping.label === 'username' ? 'new-password' : undefined,
                         }),
                     });
 

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -155,6 +155,7 @@ class SettingsFields extends React.Component {
                         props: Object.assign({}, fieldBase.props, {
                             changeEvent: 'onBlur',
                             multiLine: !!mapping.multiLine,
+                            autoComplete: mapping.label === 'username' ? 'new-password' : undefined,
                         }),
                     });
 
@@ -163,6 +164,7 @@ class SettingsFields extends React.Component {
                         props: Object.assign({}, fieldBase.props, {
                             type: 'password',
                             changeEvent: 'onBlur',
+                            autoComplete: 'new-password',
                         }),
                     });
 


### PR DESCRIPTION
The following should be present:
- The `form` element should have `autocomplete="off"`
- In the email section, the input elements for `password` should have `autocomplete="new-password"`