### PR TITLE
fix(appearance): populate db dropdown with db locales

### DIFF
--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -23,7 +23,7 @@ const styles = {
 class LocalizedTextEditor extends React.Component {
     static getLocaleName(code) {
         return (configOptionStore.state &&
-            configOptionStore.getState().locales
+            configOptionStore.getState().uiLocales
                 .filter(locale => locale.id === code)
                 .map(locale => locale.displayName)
                 .pop()) || '';
@@ -85,7 +85,7 @@ class LocalizedTextEditor extends React.Component {
             <div>
                 <div style={styles.inset}>
                     <SelectField
-                        menuItems={(options && options.locales) || []}
+                        menuItems={(options && options.uiLocales) || []}
                         value={this.state.locale || ''}
                         floatingLabelText={this.getTranslation('select_language')}
                         onChange={this.handleChange}

--- a/src/settings-app.js
+++ b/src/settings-app.js
@@ -120,7 +120,9 @@ getManifest('manifest.webapp')
             api.get('system/flags'),
             api.get('system/styles'),
             api.get('locales/ui'),
+            api.get('locales/db'),
             api.get('userSettings', { useFallback: false }),
+        /* eslint-disable complexity */
         ]).then((results) => {
             const [
                 indicatorGroups,
@@ -146,9 +148,10 @@ getManifest('manifest.webapp')
             const styles = (results[8] || []).map(style => ({ id: style.path, displayName: style.name }));
 
             // Locales
-            const locales = (results[9] || []).map(locale => ({ id: locale.locale, displayName: locale.name }));
+            const uiLocales = (results[9] || []).map(locale => ({ id: locale.locale, displayName: locale.name }));
+            const dbLocales = (results[10] || []).map(locale => ({ id: locale.locale, displayName: locale.name }));
 
-            const userSettingsNoFallback = results[10];
+            const userSettingsNoFallback = results[11];
 
             configOptionStore.setState({
                 indicatorGroups,
@@ -160,7 +163,8 @@ getManifest('manifest.webapp')
                 startModules,
                 flags,
                 styles,
-                locales,
+                uiLocales,
+                dbLocales,
                 userSettingsNoFallback,
             });
             log.debug('Got settings options:', configOptionStore.getState());

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -340,14 +340,14 @@ const settingsKeyMapping = {
         type: 'dropdown',
         userSettingsOverride: true,
         searchLabels: ['style', 'can_be_overridden_by_user_settings'],
-        source: 'locales',
+        source: 'uiLocales',
     },
     keyDbLocale: {
         label: 'db_locale',
         type: 'dropdown',
         userSettingsOverride: true,
         searchLabels: ['style', 'can_be_overridden_by_user_settings'],
-        source: 'locales',
+        source: 'dbLocales',
     },
     keyAnalysisDisplayProperty: {
         label: 'analysis_display_property',


### PR DESCRIPTION
Prior to this fix, both the DB-locales and the UI-locales dropdown were populated with the same options.