### PR TITLE
fix: adjust localised appearance settings to new endpoint implementation

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -331,5 +331,4 @@ key_hide_monthly_periods=Hide monthly periods
 key_hide_bi_monthly_periods=Hide bimonthly periods
 
 key_skip_zero_values_in_analytics_table_export=Skip zero data values in analytics tables
-system_default=System default (fallback)
 could_not_fetch_localized_settings=Could not fetch localized settings

--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -331,3 +331,5 @@ key_hide_monthly_periods=Hide monthly periods
 key_hide_bi_monthly_periods=Hide bimonthly periods
 
 key_skip_zero_values_in_analytics_table_export=Skip zero data values in analytics tables
+system_default=System default (fallback)
+could_not_fetch_localized_settings=Could not fetch localized settings

--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -331,4 +331,5 @@ key_hide_monthly_periods=Hide monthly periods
 key_hide_bi_monthly_periods=Hide bimonthly periods
 
 key_skip_zero_values_in_analytics_table_export=Skip zero data values in analytics tables
+system_default=System default (fallback)
 could_not_fetch_localized_settings=Could not fetch localized settings

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "48": "icon.png"
     },
     "dhis2": {
-      "apiVersion": "30"
+      "apiVersion": "33"
     },
     "activities": {
       "dhis": {

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -108,13 +108,9 @@ class LocalizedTextEditor extends React.Component {
 
     fetchLocalizedAppearanceSettings(locale) {
         const api = this.context.d2.Api.getApi();
-        const headers = new Headers({
-            'Content-Type': 'text/plain',
-            'Accept': 'text/plain',
-        });
         
         return Promise.all(LOCALIZED_SETTING_KEYS.map(key => 
-            api.get(`systemSettings/${key}`, { locale }, { headers })
+            api.get(`systemSettings/${key}`, { locale }).then(json => json[key])
         ));
     }
 

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -9,22 +9,6 @@ import settingsActions from '../settingsActions';
 import configOptionStore from '../configOptionStore';
 import settingsKeyMapping from '../settingsKeyMapping';
 
-/**
- * To understand why this component works the way it does, some background knowledge is required:
- * 
- * The default values of these appearance settings cannot be fetched via `/systemSettings/<key>`
- * because this keyed endpoint applies translation. However, the default values for the appearance
- * settings can be obtained when calling `/systemSettings`, because this endpoint doesn't apply
- * translations. As such, the default values are already present in the `settingsStore`.
- * 
- * When posting settings for a specific locale, we need to add a `locale` query parameter like so:
- * `/systemSettings/<key>?locale=<locale>`. To make this work a dedicated function has been created
- * in `src/settingsActions.js` called `saveLocalizedAppearanceSetting`. However, when we want to
- * update a default value, we need to omit the `locale` query parameter. Effectively his means that
- * updating a default appearance setting is identical to updating a regular setting, so it can just
- * be handled by the `saveSetting` function.
- */
-
 const styles = {
     inset: {
         padding: '0 16px 8px',

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -44,6 +44,7 @@ const styles = {
         padding: 12,
     }
 };
+const SYSTEM_DEFAULT = '@@__SYSTEM_DEFAULT__@@';
 
 const LOCALIZED_SETTING_KEYS = [
     'applicationTitle',
@@ -52,6 +53,11 @@ const LOCALIZED_SETTING_KEYS = [
     'keyApplicationFooter',
     'keyApplicationRightFooter',
 ];
+
+const readDefaultAppearanceSettingsFromStore = () => 
+    Promise.resolve(LOCALIZED_SETTING_KEYS.map(key =>
+        settingsStore.state && settingsStore.state[key]
+    ));
 
 class LocalizedTextEditor extends React.Component {
     static getLocaleName(code) {
@@ -84,8 +90,11 @@ class LocalizedTextEditor extends React.Component {
 
     getAppearanceSettings(code) {
         const locale = code || this.state.locale
+        const promise = locale === SYSTEM_DEFAULT
+            ? readDefaultAppearanceSettingsFromStore()
+            : this.fetchLocalizedAppearanceSettings(locale);
         
-        this.fetchLocalizedAppearanceSettings(locale).then(values => {
+        promise.then(values => {
             this.settings = LOCALIZED_SETTING_KEYS.reduce((acc, key, i) => {
                 acc[key] = values[i];
                 return acc;
@@ -99,9 +108,13 @@ class LocalizedTextEditor extends React.Component {
 
     fetchLocalizedAppearanceSettings(locale) {
         const api = this.context.d2.Api.getApi();
+        const headers = new Headers({
+            'Content-Type': 'text/plain',
+            'Accept': 'text/plain',
+        });
         
         return Promise.all(LOCALIZED_SETTING_KEYS.map(key => 
-            api.get(`systemSettings/${key}`, { locale }).then(json => json[key])
+            api.get(`systemSettings/${key}`, { locale }, { headers })
         ));
     }
 
@@ -119,7 +132,8 @@ class LocalizedTextEditor extends React.Component {
 
     saveSettingsKey(key, value) {
         this.settings[key] = value;
-        settingsActions.saveKey(key, value, this.state.locale);
+        const locale = this.state.locale === SYSTEM_DEFAULT ? null : this.state.locale;
+        settingsActions.saveKey(key, value, locale);
     }
 
     renderLocalizedAppearanceFields() {
@@ -151,14 +165,19 @@ class LocalizedTextEditor extends React.Component {
     }
 
     render() {
+        const systemDefaultOption = {
+            id: SYSTEM_DEFAULT, 
+            displayName: this.getTranslation('system_default')
+        };
         const optionStoreState = configOptionStore.getState();
         const uiLocales = (optionStoreState && optionStoreState.uiLocales) || [];
+        const options = [ systemDefaultOption, ...uiLocales ];
 
         return (
             <div>
                 <div style={styles.inset}>
                     <SelectField
-                        menuItems={uiLocales}
+                        menuItems={options}
                         value={this.state.locale || ''}
                         floatingLabelText={this.getTranslation('select_language')}
                         onChange={this.handleChange}

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -9,6 +9,22 @@ import settingsActions from '../settingsActions';
 import configOptionStore from '../configOptionStore';
 import settingsKeyMapping from '../settingsKeyMapping';
 
+/**
+ * To understand why this component works the way it does, some background knowledge is required:
+ * 
+ * The default values of these appearance settings cannot be fetched via `/systemSettings/<key>`
+ * because this keyed endpoint applies translation. However, the default values for the appearance
+ * settings can be obtained when calling `/systemSettings`, because this endpoint doesn't apply
+ * translations. As such, the default values are already present in the `settingsStore`.
+ * 
+ * When posting settings for a specific locale, we need to add a `locale` query parameter like so:
+ * `/systemSettings/<key>?locale=<locale>`. To make this work a dedicated function has been created
+ * in `src/settingsActions.js` called `saveLocalizedAppearanceSetting`. However, when we want to
+ * update a default value, we need to omit the `locale` query parameter. Effectively his means that
+ * updating a default appearance setting is identical to updating a regular setting, so it can just
+ * be handled by the `saveSetting` function.
+ */
+
 const styles = {
     inset: {
         padding: '0 16px 8px',

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -17,30 +17,53 @@ const settingsActions = Action.createActionsFromNames([
     'showSnackbarMessage',
 ]);
 
+const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
+    const api = d2.Api.getApi();
+    const localeSuffix = locale ? `?locale=${locale}` : '';
+    const url = `/systemSettings/${key}${localeSuffix}`;
+    const headers = new Headers({
+        'Content-Type': 'text/plain',
+        'Accept': 'text/plain',
+    })
+
+    return api.post(url, value, { headers })
+        .then(() => {
+            settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+        })
+        .catch((err) => {
+            log.warn('Failed to save localized setting:', err);
+        });
+}
+
+const saveConfiguration = (d2, key, value) => d2.system.configuration.set(key, value)
+    .then(() => {
+        settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+    })
+    .catch((err) => {
+        log.warn('Failed to save configuration:', err);
+    });
+
+const saveSetting = (d2, key, value) => d2.system.settings.set(key, value)
+    .then(() => {
+        settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+    })
+    .catch((err) => {
+        log.warn('Failed to save setting:', err);
+    });
+
 // settingsActions.saveKey handler
 settingsActions.saveKey.subscribe((args) => {
-    const [fieldData, value] = args.data;
-    const key = Array.isArray(fieldData) ? fieldData.join('') : fieldData;
-    const mappingKey = Array.isArray(fieldData) ? fieldData[0] : fieldData;
-    const mapping = settingsKeyMapping[mappingKey];
+    const [key, value, locale] = args.data;
+    const mapping = settingsKeyMapping[key];
 
     getD2().then((d2) => {
-        if (mapping.configuration) {
-            d2.system.configuration.set(key, value)
-                .then(() => {
-                    settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
-                })
-                .catch((err) => {
-                    log.warn('Failed to save configuration:', err);
-                });
+        if (mapping.appendLocale && locale) {
+            saveLocalizedAppearanceSetting(d2, key, value, locale)
+        }
+        else if (mapping.configuration) {
+            saveConfiguration(d2, key, value)
         } else {
-            d2.system.settings.set(key, value)
-                .then(() => {
-                    settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
-                })
-                .catch((err) => {
-                    log.warn('Failed to save setting:', err);
-                });
+            saveSetting(d2, key, value)
         }
 
         settingsStore.state[key] = value;

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -19,14 +19,10 @@ const settingsActions = Action.createActionsFromNames([
 
 const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
     const api = d2.Api.getApi();
-    const localeSuffix = locale ? `?locale=${locale}` : '';
-    const url = `/systemSettings/${key}${localeSuffix}`;
-    const headers = new Headers({
-        'Content-Type': 'text/plain',
-        'Accept': 'text/plain',
-    })
+    const localeSuffix = locale ? `&locale=${locale}` : '';
+    const url = `/systemSettings/${key}?value=${value}${localeSuffix}`;
 
-    return api.post(url, value, { headers })
+    return api.post(url)
         .then(() => {
             settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
         })

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -19,14 +19,9 @@ const settingsActions = Action.createActionsFromNames([
 
 const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
     const api = d2.Api.getApi();
-    const localeSuffix = locale ? `?locale=${locale}` : '';
-    const url = `/systemSettings/${key}${localeSuffix}`;
-    const headers = new Headers({
-        'Content-Type': 'text/plain',
-        'Accept': 'text/plain',
-    })
+    const url = `/systemSettings/${key}?value=${value}&locale=${locale}`;
 
-    return api.post(url, value, { headers })
+    return api.post(url)
         .then(() => {
             settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
         })

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -19,9 +19,14 @@ const settingsActions = Action.createActionsFromNames([
 
 const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
     const api = d2.Api.getApi();
-    const url = `/systemSettings/${key}?value=${value}&locale=${locale}`;
+    const localeSuffix = locale ? `?locale=${locale}` : '';
+    const url = `/systemSettings/${key}${localeSuffix}`;
+    const headers = new Headers({
+        'Content-Type': 'text/plain',
+        'Accept': 'text/plain',
+    })
 
-    return api.post(url)
+    return api.post(url, value, { headers })
         .then(() => {
             settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
         })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const { NODE_ENV, DHIS2_HOME } = process.env;
 const isProd = NODE_ENV === 'production';
 const dhisConfigPath = DHIS2_HOME && path.join(DHIS2_HOME, 'config');
 let dhisConfig = {
-    baseUrl: 'http://localhost:8080/dhis',
+    baseUrl: 'http://localhost:8080',
     authorization: 'Basic YWRtaW46ZGlzdHJpY3Q=', // admin:district
 };
 


### PR DESCRIPTION
### UPDATE
- The endpoint now accepts JSON payloads so I was able to stop using custom headers for text/plain
- ~For now, we are just editing the localized values here. We have removed support for editing default values, because it is undecided if that is required at all, see this [JIRA issue](https://jira.dhis2.org/browse/DHIS2-8182).~ After discussing with @amcgee it was decided that it'd be better to keep support for editing the default/fallback values should still be supported too. That makes the code quite a bit more complex. Hopefully we can clean it up after 8182 is done.

---

ON HOLD: Currently we are working with an endpoint that only accepts plain text requests. This is going to change, and this will allow me to clean the code up a bit

I think this comment explains it all really 🤕 
https://github.com/dhis2/settings-app/blob/e3d068c7a30a204054a4982f42e5f9054c6326cf/src/localized-text/LocalizedAppearanceEditor.component.js#L12-L26