### PR TITLE
fix: backport dhis2-6128 to v32

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -330,3 +330,5 @@ key_hide_monthly_periods=Hide monthly periods
 key_hide_bi_monthly_periods=Hide bimonthly periods
 
 key_skip_zero_values_in_analytics_table_export=Skip zero data values in analytics tables
+system_default=System default (fallback)
+could_not_fetch_localized_settings=Could not fetch localized settings

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "48": "icon.png"
     },
     "dhis2": {
-      "apiVersion": "33"
+      "apiVersion": "32"
     },
     "activities": {
       "dhis": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       "48": "icon.png"
     },
     "dhis2": {
-      "apiVersion": "30"
+      "apiVersion": "33"
     },
     "activities": {
       "dhis": {

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -102,9 +102,14 @@ class LocalizedTextEditor extends React.Component {
 
     fetchLocalizedAppearanceSettings(locale) {
         const api = this.context.d2.Api.getApi();
-        
-        return Promise.all(LOCALIZED_SETTING_KEYS.map(key => 
-            api.get(`systemSettings/${key}`, { locale }).then(json => json[key])
+        const headers = new Headers({
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        });
+
+        return Promise.all(LOCALIZED_SETTING_KEYS.map(key =>
+            api.get(`systemSettings/${key}`, { locale }, { headers })
+                .then(json => json[key])
         ));
     }
 

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -1,12 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component';
+import CircularProgress from 'material-ui/CircularProgress';
 import TextField from '../form-fields/text-field';
 import SelectField from '../form-fields/drop-down';
-import settingsActions from '../settingsActions';
 import settingsStore from '../settingsStore';
+import settingsActions from '../settingsActions';
 import configOptionStore from '../configOptionStore';
 import settingsKeyMapping from '../settingsKeyMapping';
+
+/**
+ * To understand why this component works the way it does, some background knowledge is required:
+ * 
+ * The default values of these appearance settings cannot be fetched via `/systemSettings/<key>`
+ * because this keyed endpoint applies translation. However, the default values for the appearance
+ * settings can be obtained when calling `/systemSettings`, because this endpoint doesn't apply
+ * translations. As such, the default values are already present in the `settingsStore`.
+ * 
+ * When posting settings for a specific locale, we need to add a `locale` query parameter like so:
+ * `/systemSettings/<key>?locale=<locale>`. To make this work a dedicated function has been created
+ * in `src/settingsActions.js` called `saveLocalizedAppearanceSetting`. However, when we want to
+ * update a default value, we need to omit the `locale` query parameter. Effectively his means that
+ * updating a default appearance setting is identical to updating a regular setting, so it can just
+ * be handled by the `saveSetting` function.
+ */
 
 const styles = {
     inset: {
@@ -18,7 +35,24 @@ const styles = {
     field: {
         width: '100%',
     },
+    loaderWrap: {
+        textAlign: 'center',
+        padding: 12,
+    },
+    error: {
+        color: 'red',
+        padding: 12,
+    }
 };
+const SYSTEM_DEFAULT = '@@__SYSTEM_DEFAULT__@@';
+
+const LOCALIZED_SETTING_KEYS = [
+    'applicationTitle',
+    'keyApplicationIntro',
+    'keyApplicationNotification',
+    'keyApplicationFooter',
+    'keyApplicationRightFooter',
+];
 
 class LocalizedTextEditor extends React.Component {
     static getLocaleName(code) {
@@ -35,6 +69,8 @@ class LocalizedTextEditor extends React.Component {
         this.state = {
             locale: settingsStore.state.keyUiLocale,
             localeName: LocalizedTextEditor.getLocaleName(settingsStore.state.keyUiLocale),
+            settings: null,
+            error: false,
         };
 
         this.handleChange = this.handleChange.bind(this);
@@ -42,35 +78,75 @@ class LocalizedTextEditor extends React.Component {
         this.getTranslation = context.d2.i18n.getTranslation.bind(context.d2.i18n);
     }
 
+    componentDidMount() {
+        this.getAppearanceSettings();
+    }
+
+    getAppearanceSettings(code) {
+        const locale = code || this.state.locale
+        const promise = locale === SYSTEM_DEFAULT
+            ? Promise.resolve(LOCALIZED_SETTING_KEYS.map(key => settingsStore.state[key]))
+            : this.fetchLocalizedAppearanceSettings(locale);
+        
+        promise.then(values => {
+            const settings = LOCALIZED_SETTING_KEYS.reduce((acc, key, i) => {
+                acc[key] = values[i];
+                return acc;
+            }, {});
+
+            this.setState({ settings, error: false });
+        }).catch(() => {
+            this.setState({ error: true, settings: null });
+        })
+    }
+
+    fetchLocalizedAppearanceSettings(locale) {
+        const api = this.context.d2.Api.getApi();
+        
+        return Promise.all(LOCALIZED_SETTING_KEYS.map(key => 
+            api.get(`systemSettings/${key}`, { locale }).then(json => json[key])
+        ));
+    }
+
     handleChange(e) {
+        const code = e.target.value;
+
         this.setState({
-            locale: e.target.value,
-            localeName: LocalizedTextEditor.getLocaleName(e.target.value),
+            locale: code,
+            localeName: LocalizedTextEditor.getLocaleName(code),
+            settings: null,
         });
+
+        this.getAppearanceSettings(code);
     }
 
     saveSettingsKey(key, value) {
-        if (this.state.locale === 'en') {
-            settingsActions.saveKey(key, value);
-        } else {
-            settingsActions.saveKey([key, this.state.locale], value);
-        }
+        this.setState({
+            settings: {
+                ...this.state.settings,
+                [key]: value,
+            }
+        })
+        const locale = this.state.locale === SYSTEM_DEFAULT ? null : this.state.locale;
+        settingsActions.saveKey(key, value, locale);
     }
 
-    /* eslint-disable complexity */
-    render() {
-        const keys = [
-            'applicationTitle',
-            'keyApplicationIntro',
-            'keyApplicationNotification',
-            'keyApplicationFooter',
-            'keyApplicationRightFooter',
-        ];
-        const localeAppendage = this.state.locale === 'en' ? '' : this.state.locale;
+    renderLocalizedAppearanceFields() {
+        if (!this.state.settings && !this.state.error) {
+            return <div style={styles.loaderWrap}><CircularProgress /></div>;
+        }
 
-        const fields = keys.map(key => ({
+        if (this.state.error) {
+            return (
+                <div style={styles.error}>
+                    {this.getTranslation('could_not_fetch_localized_settings')}
+                </div>
+            );
+        }
+
+        const fields = LOCALIZED_SETTING_KEYS.map(key => ({
             name: key,
-            value: (settingsStore.state && settingsStore.state[key + localeAppendage]) || '',
+            value: this.state.settings[key] || '',
             component: TextField,
             props: {
                 floatingLabelText: `${this.getTranslation(settingsKeyMapping[key].label)} - ${this.state.localeName}`,
@@ -80,23 +156,34 @@ class LocalizedTextEditor extends React.Component {
             },
         }));
 
-        const options = configOptionStore.getState();
+        return <FormBuilder fields={fields} onUpdateField={this.saveSettingsKey} />
+    }
+
+    render() {
+        const systemDefaultOption = {
+            id: SYSTEM_DEFAULT, 
+            displayName: this.getTranslation('system_default')
+        };
+        const optionStoreState = configOptionStore.getState();
+        const uiLocales = (optionStoreState && optionStoreState.uiLocales) || [];
+        const options = [ systemDefaultOption, ...uiLocales ];
+
         return (
             <div>
                 <div style={styles.inset}>
                     <SelectField
-                        menuItems={(options && options.uiLocales) || []}
+                        menuItems={options}
                         value={this.state.locale || ''}
                         floatingLabelText={this.getTranslation('select_language')}
                         onChange={this.handleChange}
                     />
-                    { this.state.locale && <FormBuilder fields={fields} onUpdateField={this.saveSettingsKey} /> }
+                    { this.state.locale && this.renderLocalizedAppearanceFields() }
                 </div>
             </div>
         );
     }
-    /* eslint-enable */
 }
+
 LocalizedTextEditor.contextTypes = {
     d2: PropTypes.object.isRequired,
 };

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -53,7 +53,9 @@ settingsActions.saveKey.subscribe((args) => {
     const mapping = settingsKeyMapping[key];
 
     getD2().then((d2) => {
-        if (mapping.appendLocale && locale) {
+        const isLocalisedAppearanceSetting = mapping.appendLocale && locale;
+
+        if (isLocalisedAppearanceSetting) {
             saveLocalizedAppearanceSetting(d2, key, value, locale)
         }
         else if (mapping.configuration) {
@@ -62,8 +64,10 @@ settingsActions.saveKey.subscribe((args) => {
             saveSetting(d2, key, value)
         }
 
-        settingsStore.state[key] = value;
-        settingsStore.setState(settingsStore.state);
+        if (!isLocalisedAppearanceSetting) {
+            settingsStore.state[key] = value;
+            settingsStore.setState(settingsStore.state);
+        }
     });
 });
 

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -21,8 +21,12 @@ const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
     const api = d2.Api.getApi();
     const localeSuffix = locale ? `&locale=${locale}` : '';
     const url = `/systemSettings/${key}?value=${value}${localeSuffix}`;
+    const headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    };
 
-    return api.post(url)
+    return api.post(url, '', { headers })
         .then(() => {
             settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
         })

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -17,30 +17,49 @@ const settingsActions = Action.createActionsFromNames([
     'showSnackbarMessage',
 ]);
 
+const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
+    const api = d2.Api.getApi();
+    const localeSuffix = locale ? `&locale=${locale}` : '';
+    const url = `/systemSettings/${key}?value=${value}${localeSuffix}`;
+
+    return api.post(url)
+        .then(() => {
+            settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+        })
+        .catch((err) => {
+            log.warn('Failed to save localized setting:', err);
+        });
+}
+
+const saveConfiguration = (d2, key, value) => d2.system.configuration.set(key, value)
+    .then(() => {
+        settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+    })
+    .catch((err) => {
+        log.warn('Failed to save configuration:', err);
+    });
+
+const saveSetting = (d2, key, value) => d2.system.settings.set(key, value)
+    .then(() => {
+        settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
+    })
+    .catch((err) => {
+        log.warn('Failed to save setting:', err);
+    });
+
 // settingsActions.saveKey handler
 settingsActions.saveKey.subscribe((args) => {
-    const [fieldData, value] = args.data;
-    const key = Array.isArray(fieldData) ? fieldData.join('') : fieldData;
-    const mappingKey = Array.isArray(fieldData) ? fieldData[0] : fieldData;
-    const mapping = settingsKeyMapping[mappingKey];
+    const [key, value, locale] = args.data;
+    const mapping = settingsKeyMapping[key];
 
     getD2().then((d2) => {
-        if (mapping.configuration) {
-            d2.system.configuration.set(key, value)
-                .then(() => {
-                    settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
-                })
-                .catch((err) => {
-                    log.warn('Failed to save configuration:', err);
-                });
+        if (mapping.appendLocale && locale) {
+            saveLocalizedAppearanceSetting(d2, key, value, locale)
+        }
+        else if (mapping.configuration) {
+            saveConfiguration(d2, key, value)
         } else {
-            d2.system.settings.set(key, value)
-                .then(() => {
-                    settingsActions.showSnackbarMessage(d2.i18n.getTranslation('settings_updated'));
-                })
-                .catch((err) => {
-                    log.warn('Failed to save setting:', err);
-                });
+            saveSetting(d2, key, value)
         }
 
         settingsStore.state[key] = value;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const { NODE_ENV, DHIS2_HOME } = process.env;
 const isProd = NODE_ENV === 'production';
 const dhisConfigPath = DHIS2_HOME && path.join(DHIS2_HOME, 'config');
 let dhisConfig = {
-    baseUrl: 'http://localhost:8080/dhis',
+    baseUrl: 'http://localhost:8080',
     authorization: 'Basic YWRtaW46ZGlzdHJpY3Q=', // admin:district
 };
 


### PR DESCRIPTION
I made sure the api version for this version was set to v32.

NOTE: this also includes the changes from https://github.com/dhis2/settings-app/pull/406

Summary (https://github.com/dhis2/settings-app/pull/375):
 * fix: adjust localised appearance settings to new endpoint implementation
 * fix(localized-appearances): request as json and stop editing defaults
 * chore(localized-appearance): remove comment describing old complexities
 * chore: remove redundant i18n string
 * Revert "chore: remove redundant i18n string"
    - This reverts commit 2c660b85e4d01c5f2f3e129fc0920eca060d55f4.
 * Revert "chore(localized-appearance): remove comment describing old complexities"
    - This reverts commit a621c002892b9f0377003cc924a9a68bdb775693.
 * Revert "fix(localized-appearances): request as json and stop editing defaults"
    - This reverts commit d34c203984a43ff8b218c918017ff8d1d747a0d3.
 * fix(localized-appearance): use json payloads
 * refactor: use settings as state property and remove helper

Summary (https://github.com/dhis2/settings-app/pull/406):
 * fix: prevent updating setting-store-state from localized-settings