### PR TITLE
fix: prevent updating setting-store-state from localized-settings

### DIFF
--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -53,7 +53,9 @@ settingsActions.saveKey.subscribe((args) => {
     const mapping = settingsKeyMapping[key];
 
     getD2().then((d2) => {
-        if (mapping.appendLocale && locale) {
+        const isLocalisedAppearanceSetting = mapping.appendLocale && locale;
+
+        if (isLocalisedAppearanceSetting) {
             saveLocalizedAppearanceSetting(d2, key, value, locale)
         }
         else if (mapping.configuration) {
@@ -62,8 +64,10 @@ settingsActions.saveKey.subscribe((args) => {
             saveSetting(d2, key, value)
         }
 
-        settingsStore.state[key] = value;
-        settingsStore.setState(settingsStore.state);
+        if (!isLocalisedAppearanceSetting) {
+            settingsStore.state[key] = value;
+            settingsStore.setState(settingsStore.state);
+        }
     });
 });
 


### PR DESCRIPTION
There was a problem in https://github.com/dhis2/settings-app/pull/375:
- After updating a localized setting this value would be updated in the database correctly
- But it would also update the `settingStore.state`, which should have only been containing the default values

This fix only updates the settng-store state when a field is not a localized appearance setting. Effectively this covers the default value of an appearance setting, and any other (non-localised) field.