### PR TITLE
fix: disable untranslated localized fields and add help texts (v31)

### DIFF
--- a/i18n/module/i18n_module_en.properties
+++ b/i18n/module/i18n_module_en.properties
@@ -326,3 +326,5 @@ manage_my_apps=Manage my apps
 
 system_default=System default (fallback)
 could_not_fetch_localized_settings=Could not fetch localized settings
+set_main_value_first=Set the main field value before adding a translation
+default_value=System default (fallback)

--- a/src/form-fields/text-field.js
+++ b/src/form-fields/text-field.js
@@ -1,42 +1,56 @@
 import React from 'react';
 import TextField from 'material-ui/TextField';
 
-import MuiThemeMixin from '../mui-theme.mixin';
+const helpTextStyle = {
+    fontSize: '12px',
+    color: 'rgba(0, 0, 0, 0.3)',
+    margin: '-4px 0 0',
+}
 
+class TextFieldComponent extends React.Component {
+    constructor(props) {
+        super(props);
 
-// TODO: Rewrite as ES6 class
-/* eslint-disable react/prefer-es6-class */
-export default React.createClass({
-    propTypes: {
-        value: React.PropTypes.string,
-        multiLine: React.PropTypes.bool,
-    },
-
-    mixins: [MuiThemeMixin],
-
-    getInitialState() {
-        return {
-            value: this.props.value,
-        };
-    },
+        this.onChange = this.onChange.bind(this);
+        this.state = {
+            value: props.value,
+        }
+    }
 
     componentWillReceiveProps(props) {
         this.setState({ value: props.value });
-    },
+    }
 
     onChange(e) {
         this.setState({ value: e.target.value });
-    },
+    }
 
     render() {
-        const { changeEvent, isRequired, defaultValue, ...other } = this.props; // eslint-disable-line
+        const { changeEvent, isRequired, defaultValue, helpText, ...other } = this.props; // eslint-disable-line
         const errorStyle = {
             lineHeight: this.props.multiLine ? '48px' : '12px',
             marginTop: this.props.multiLine ? -16 : 0,
         };
 
         return (
+          <div>
             <TextField errorStyle={errorStyle} {...other} value={this.state.value} onChange={this.onChange} />
+            {helpText && <p style={helpTextStyle}>{helpText}</p>}
+          </div>
         );
-    },
-});
+    }
+}
+
+TextFieldComponent.propTypes = {
+    value: React.PropTypes.string,
+    multiLine: React.PropTypes.bool,
+    helpText: React.PropTypes.node,
+}
+
+TextFieldComponent.defaultProps = {
+    value: '',
+    multiLine: false,
+    helpText: '',
+}
+
+export default TextFieldComponent;

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -80,6 +80,8 @@ class LocalizedTextEditor extends React.Component {
 
         this.handleChange = this.handleChange.bind(this);
         this.saveSettingsKey = this.saveSettingsKey.bind(this);
+        this.switchToDefaultLocale = this.switchToDefaultLocale.bind(this);
+        this.createFieldHelpTextProps = this.createFieldHelpTextProps.bind(this);
         this.getTranslation = context.d2.i18n.getTranslation.bind(context.d2.i18n);
     }
 
@@ -130,7 +132,7 @@ class LocalizedTextEditor extends React.Component {
         this.getAppearanceSettings(code);
     }
 
-    switchToDefaultLocale = () => {
+    switchToDefaultLocale() {
         this.handleChange({target: { value: SYSTEM_DEFAULT}})
     }
 
@@ -145,7 +147,7 @@ class LocalizedTextEditor extends React.Component {
         settingsActions.saveKey(key, value, locale);
     }
 
-    createFieldHelpTextProps = (fieldKey) => {
+    createFieldHelpTextProps(fieldKey) {
         const defaultValue = settingsStore.state[fieldKey]
         const { locale } = this.state
 
@@ -163,9 +165,9 @@ class LocalizedTextEditor extends React.Component {
             disabled: true,
             helpText: (
                 // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-                <span style={styles.clickableHelpText} onClick={this.switchToDefaultLocale}>
-                    {this.getTranslation('set_main_value_first')}
-                </span>
+              <span style={styles.clickableHelpText} onClick={this.switchToDefaultLocale}>
+                {this.getTranslation('set_main_value_first')}
+              </span>
             ),
         }
     }

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -42,7 +42,12 @@ const styles = {
     error: {
         color: 'red',
         padding: 12,
-    }
+    },
+    clickableHelpText: {
+        color: '#3162C5',
+        textDecoration: 'underline',
+        cursor: 'pointer',
+    },
 };
 const SYSTEM_DEFAULT = '@@__SYSTEM_DEFAULT__@@';
 
@@ -125,6 +130,10 @@ class LocalizedTextEditor extends React.Component {
         this.getAppearanceSettings(code);
     }
 
+    switchToDefaultLocale = () => {
+        this.handleChange({target: { value: SYSTEM_DEFAULT}})
+    }
+
     saveSettingsKey(key, value) {
         this.setState({
             settings: {
@@ -134,6 +143,31 @@ class LocalizedTextEditor extends React.Component {
         })
         const locale = this.state.locale === SYSTEM_DEFAULT ? null : this.state.locale;
         settingsActions.saveKey(key, value, locale);
+    }
+
+    createFieldHelpTextProps = (fieldKey) => {
+        const defaultValue = settingsStore.state[fieldKey]
+        const { locale } = this.state
+
+        if (locale === SYSTEM_DEFAULT) {
+            return null;
+        }
+
+        if (defaultValue) {
+            return {
+                helpText: `${this.getTranslation('default_value')}: ${defaultValue}`
+            };
+        }
+
+        return {
+            disabled: true,
+            helpText: (
+                // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+                <span style={styles.clickableHelpText} onClick={this.switchToDefaultLocale}>
+                    {this.getTranslation('set_main_value_first')}
+                </span>
+            ),
+        }
     }
 
     renderLocalizedAppearanceFields() {
@@ -154,10 +188,11 @@ class LocalizedTextEditor extends React.Component {
             value: this.state.settings[key] || '',
             component: TextField,
             props: {
-                floatingLabelText: `${this.getTranslation(settingsKeyMapping[key].label)} - ${this.state.localeName}`,
+                floatingLabelText: `${this.getTranslation(settingsKeyMapping[key].label)} - ${(this.state.localeName || this.getTranslation('system_default'))}`,
                 changeEvent: 'onBlur',
                 style: styles.field,
                 multiLine: true,
+                ...this.createFieldHelpTextProps(key),
             },
         }));
 


### PR DESCRIPTION
This backport required some manual intervention in the `text-field.js` due to merge conflicts. I have tested that it works locally.