### PR TITLE
fix: return cache strategy field to analytics section

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -19,7 +19,6 @@ export const categories = {
         settings: [
             'keyAnalyticsMaxLimit',
             'keySqlViewMaxLimit',
-            'keyCacheStrategy',
             'infrastructuralIndicators',
             'infrastructuralDataElements',
             'infrastructuralPeriodType',
@@ -43,6 +42,7 @@ export const categories = {
             'keyHideMonthlyPeriods',
             'keyHideBiMonthlyPeriods',
             'analyticsFinancialYearStart',
+            'keyCacheStrategy',
             'keyCacheability',
             'keyAnalyticsCacheTtlMode',
             'keyAnalyticsCacheProgressiveTtlFactor',


### PR DESCRIPTION
This simply moves the "Cache strategy" field back to the analytics section, where it was before.