### PR TITLE
feat: hide biweekly periods (DHIS2-11165)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-25T22:14:19.666Z\n"
-"PO-Revision-Date: 2021-03-25T22:14:19.666Z\n"
+"POT-Creation-Date: 2021-05-19T08:58:48.266Z\n"
+"PO-Revision-Date: 2021-05-19T08:58:48.266Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr ""
@@ -27,9 +27,6 @@ msgid "Preview of image"
 msgstr ""
 
 msgid "Upload image"
-msgstr ""
-
-msgid "File uploaded successfully"
 msgstr ""
 
 msgid "Error uploading file: {{error}}"
@@ -435,6 +432,9 @@ msgid "Hidden period types in analytics apps"
 msgstr ""
 
 msgid "Hide weekly periods"
+msgstr ""
+
+msgid "Hide biweekly periods"
 msgstr ""
 
 msgid "Hide monthly periods"

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -43,6 +43,7 @@ export const categories = {
             'keyAnalysisRelativePeriod',
             'keyHideDailyPeriods',
             'keyHideWeeklyPeriods',
+            'keyHideBiWeeklyPeriods',
             'keyHideMonthlyPeriods',
             'keyHideBiMonthlyPeriods',
             'analyticsFinancialYearStart',

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -159,6 +159,10 @@ const settingsKeyMapping = {
         label: i18n.t('Hide weekly periods'),
         type: 'checkbox',
     },
+    keyHideBiWeeklyPeriods: {
+        label: i18n.t('Hide biweekly periods'),
+        type: 'checkbox',
+    },
     keyHideMonthlyPeriods: {
         label: i18n.t('Hide monthly periods'),
         type: 'checkbox',


### PR DESCRIPTION
**DO NOT MERGE**: Wait for the `keyHideBiWeeklyPeriods` system setting to be implemented in the backend first: https://jira.dhis2.org/browse/DHIS2-11166

Adds a checkbox for hiding biweekly periods.

Before:

![Screenshot from 2021-05-19 11-03-48](https://user-images.githubusercontent.com/1010094/118786645-51150480-b892-11eb-906a-03e5dc9caab9.png)

After:

![Screenshot from 2021-05-19 11-03-32](https://user-images.githubusercontent.com/1010094/118786653-540ff500-b892-11eb-9e0d-8182c4764332.png)
