### PR TITLE
fix: use '-:-' instead of null as i18n namespace separator

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -89,7 +89,7 @@ const AppWrapper = () => {
                 <p>
                     {i18n.t('Failed to load: {{error}}', {
                         error: error.message,
-                        nsSeparator: null,
+                        nsSeparator: '-:-',
                     })}
                 </p>
             </CenteredContent>

--- a/src/form-fields/file-upload.js
+++ b/src/form-fields/file-upload.js
@@ -152,7 +152,7 @@ class FileUpload extends React.Component {
             this.props.alert.show({
                 message: i18n.t('Error uploading file: {{error}}', {
                     error: error.httpStatus || error.message,
-                    nsSeparator: null,
+                    nsSeparator: '-:-',
                 }),
                 critical: true,
             })

--- a/src/metadata-settings/metadataSettings.component.js
+++ b/src/metadata-settings/metadataSettings.component.js
@@ -259,7 +259,7 @@ class MetadataSettings extends Component {
                                 fontWeight: 'bold',
                             }}
                         >
-                            {i18n.t('Master version:', { nsSeparator: null })}
+                            {i18n.t('Master version:', { nsSeparator: '-:-' })}
                         </dt>
                         <dd style={{ display: 'inline-block' }}>
                             {this.state.masterVersionName || i18n.t('None')}

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -79,7 +79,7 @@ function wrapUserSettingsOverride({ component, valueLabel }) {
                       'This setting will be overridden by the current user setting: {{settingName}}',
                       {
                           settingName: valueLabel,
-                          nsSeparator: null,
+                          nsSeparator: '-:-',
                       }
                   )}`
                 : i18n.t('This setting can be overridden by user settings')


### PR DESCRIPTION
Using `null` as a namespace separator may cause issues if we wish to use namespaces in the future, so this PR replaces it with `'-:-'`.