### PR TITLE
fix: reorganise some analytics settings DHIS2-13110

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -42,6 +42,8 @@ export const categories = {
         pageLabel: i18n.t('Analytics settings'),
         settings: [
             'keyAnalysisRelativePeriod',
+            'keyAnalysisDisplayProperty',
+            'keyAnalysisDigitGroupSeparator',
             'keyHideDailyPeriods',
             'keyHideWeeklyPeriods',
             'keyHideBiWeeklyPeriods',
@@ -90,8 +92,6 @@ export const categories = {
             'keyFlag',
             'keyUiLocale',
             'keyDbLocale',
-            'keyAnalysisDisplayProperty',
-            'keyAnalysisDigitGroupSeparator',
             'keyRequireAddToView',
             'keyUseCustomLogoFront',
             'keyUseCustomLogoBanner',


### PR DESCRIPTION
Fixes [DHIS2-13110](https://jira.dhis2.org/browse/DHIS2-13110).

Moved settings for display name property and digit group separator from the Appearance to the Analytics section.

Before:
<img width="434" alt="Screenshot 2022-04-19 at 14 04 55" src="https://user-images.githubusercontent.com/150978/164008052-e903eb20-29c7-4589-a800-6acc21a228e5.png">

After:
<img width="387" alt="Screenshot 2022-04-19 at 14 04 34" src="https://user-images.githubusercontent.com/150978/164008035-b778b81f-666b-43cf-977c-74507d370f94.png">


