### PR TITLE
fix: show help text for sender email

### DIFF
--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -325,6 +325,7 @@ class SettingsFields extends React.Component {
                             ...addConditionallyHiddenStyles(mapping),
                         },
                         hintText: mapping.hintText,
+                        helpText: mapping.helpText,
                     },
                     validators,
                 }

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -496,6 +496,7 @@ const settingsKeyMapping = {
     },
     keyEmailSender: {
         label: i18n.t('Email sender'),
+        helpText: i18n.t('The address that outgoing messages are sent from.'),
         validators: ['email'],
     },
     emailTestButton: {


### PR DESCRIPTION
The backend was updated to not return a default email, as that behaviour has security and privacy implications. The Frontend is now updated to display help text to enter email, instead of the default email as before.

fixes [DHIS2-15189](https://dhis2.atlassian.net/browse/DHIS2-15189)

## Screenshot
<img width="1005" alt="image" src="https://github.com/dhis2/settings-app/assets/1014725/89d6e4a5-5206-457a-98ae-3abc1cb3782e">
<img width="993" alt="image" src="https://github.com/dhis2/settings-app/assets/1014725/46e78f9e-2135-4667-8878-60566d03ce82">
<img width="1037" alt="image" src="https://github.com/dhis2/settings-app/assets/1014725/9383cf91-5f55-44d1-89e2-fb7bb0df0a8e">


[DHIS2-15189]: https://dhis2.atlassian.net/browse/DHIS2-15189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ