### PR TITLE
fix: language display [DHIS2-15292]

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -157,11 +157,17 @@ const AppWrapper = () => {
 
     const uiLocales = (data.uiLocales || []).map((locale) => ({
         id: locale.locale,
-        displayName: locale.name,
+        displayName:
+            locale.name === locale.displayName
+                ? locale.name
+                : `${locale.name} — ${locale.displayName}`,
     }))
     const dbLocales = (data.dbLocales || []).map((locale) => ({
         id: locale.locale,
-        displayName: locale.name,
+        displayName:
+            locale.name === locale.displayName
+                ? locale.name
+                : `${locale.name} — ${locale.displayName}`,
     }))
 
     configOptionStore.setState({

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -260,6 +260,7 @@ class LocalizedTextEditor extends React.Component {
                         value={this.state.locale || ''}
                         floatingLabelText={i18n.t('Select language')}
                         onChange={this.handleChange}
+                        style={{ width: '100%' }}
                     />
                     {this.state.locale ? (
                         this.renderLocalizedAppearanceFields()


### PR DESCRIPTION
See [DHIS2-15292](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15292)

api/locales/db and api/locales/ui have been updated to include the language name its own language (e.g. français, Deutsch, norsk) (`name`) as well as the translation into the user's selected ui language (e.g. French, German, Norwegian) (`displayName`). This change applies as of v41.

**CURRENTLY (v41)**
Without changes, the language drop down will now display only as a list of languages in the own language (e.g. العربية, বাংলা, Bislama)

<img width="639" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/a88830cb-92d6-4afe-9a36-d92486e6b484">


**AFTER**

With changes, the language drop down shows in the format `العربية - Arabic`, `বাংলা - Bangla`, `Bislama` (where `name` and `displayName` are the same, only one is shown).

Note: The sorting of languages follows the backend logic of sorting by user's UI language (e.g. if I have selected French as my UI language, languages would be listed like `English - anglais`, ` العربية - arabe`

<img width="807" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/eced035c-7ccb-495b-aaf3-ca5ef0f60ae4">



[DHIS2-15292]: https://dhis2.atlassian.net/browse/DHIS2-15292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ