### PR TITLE
fix: appearance translations

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-27T15:56:53.590Z\n"
-"PO-Revision-Date: 2023-02-27T15:56:53.590Z\n"
+"POT-Creation-Date: 2023-08-24T10:48:48.806Z\n"
+"PO-Revision-Date: 2023-08-24T10:48:48.806Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -35,8 +35,8 @@ msgstr "Error uploading file: {{error}}"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-msgid "System default (fallback)"
-msgstr "System default (fallback)"
+msgid "System default ({{language}})"
+msgstr "System default ({{language}})"
 
 msgid "Set the main field value before adding a translation"
 msgstr "Set the main field value before adding a translation"
@@ -680,6 +680,9 @@ msgstr "TLS"
 msgid "Email sender"
 msgstr "Email sender"
 
+msgid "The address that outgoing messages are sent from."
+msgstr "The address that outgoing messages are sent from."
+
 msgid "Send me a test email"
 msgstr "Send me a test email"
 
@@ -725,8 +728,8 @@ msgstr "12 months"
 msgid "Send reminders to users before their password expires"
 msgstr "Send reminders to users before their password expires"
 
-msgid "Number of days before password expiry to send reminder (0–28)"
-msgstr "Number of days before password expiry to send reminder (0–28)"
+msgid "Number of days before password expiry to send reminder (1–28)"
+msgstr "Number of days before password expiry to send reminder (1–28)"
 
 msgid "Minimum characters in password"
 msgstr "Minimum characters in password"

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -82,12 +82,10 @@ class LocalizedTextEditor extends React.Component {
         super(props, context)
 
         this.state = {
-            locale: settingsStore.state && settingsStore.state.keyUiLocale,
+            locale: SYSTEM_DEFAULT,
             localeName:
                 settingsStore.state &&
-                LocalizedTextEditor.getLocaleName(
-                    settingsStore.state.keyUiLocale
-                ),
+                LocalizedTextEditor.getLocaleName(SYSTEM_DEFAULT),
             settings: null,
             error: false,
         }

--- a/src/localized-text/LocalizedAppearanceEditor.component.js
+++ b/src/localized-text/LocalizedAppearanceEditor.component.js
@@ -11,8 +11,6 @@ import settingsActions from '../settingsActions.js'
 import settingsKeyMapping from '../settingsKeyMapping.js'
 import settingsStore from '../settingsStore.js'
 
-const systemDefaultText = i18n.t('System default (fallback)')
-
 /**
  * To understand why this component works the way it does, some background knowledge is required:
  *
@@ -62,6 +60,13 @@ const LOCALIZED_SETTING_KEYS = [
 
 class LocalizedTextEditor extends React.Component {
     static getLocaleName(code) {
+        if (code === SYSTEM_DEFAULT) {
+            return i18n.t('System default ({{language}})', {
+                language: LocalizedTextEditor.getLocaleName(
+                    settingsStore.state.keyUiLocale
+                ),
+            })
+        }
         return (
             (configOptionStore.state &&
                 configOptionStore
@@ -95,10 +100,8 @@ class LocalizedTextEditor extends React.Component {
         this.getAppearanceSettings()
         this.settingsStoreSubscription = settingsStore.subscribe(() => {
             this.setState({
-                locale: settingsStore.state.keyUiLocale,
-                localeName: LocalizedTextEditor.getLocaleName(
-                    settingsStore.state.keyUiLocale
-                ),
+                locale: SYSTEM_DEFAULT,
+                localeName: LocalizedTextEditor.getLocaleName(SYSTEM_DEFAULT),
             })
         })
     }
@@ -187,7 +190,7 @@ class LocalizedTextEditor extends React.Component {
 
         if (defaultValue) {
             return {
-                helpText: `${systemDefaultText}: ${defaultValue}`,
+                helpText: LocalizedTextEditor.getLocaleName(SYSTEM_DEFAULT),
             }
         }
 
@@ -228,9 +231,9 @@ class LocalizedTextEditor extends React.Component {
             value: this.state.settings[key] || '',
             component: TextField,
             props: {
-                floatingLabelText: `${settingsKeyMapping[key].label} – ${
-                    this.state.localeName || systemDefaultText
-                }`,
+                floatingLabelText: `${
+                    settingsKeyMapping[key].label
+                } – ${LocalizedTextEditor.getLocaleName(this.state.locale)}`,
                 changeEvent: 'onBlur',
                 style: styles.field,
                 multiLine: true,
@@ -246,7 +249,7 @@ class LocalizedTextEditor extends React.Component {
     render() {
         const systemDefaultOption = {
             id: SYSTEM_DEFAULT,
-            displayName: systemDefaultText,
+            displayName: LocalizedTextEditor.getLocaleName(SYSTEM_DEFAULT),
         }
         const optionStoreState = configOptionStore.getState()
         const uiLocales = (optionStoreState && optionStoreState.uiLocales) || []


### PR DESCRIPTION
See ticket: https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15662


- persists language selection between translations [original bug]
- changes default language for editing appearance settings to the DHIS2 system default language [discussed/approved with Karoline+Joe]
- changes text for default language for appearance settings from `System default (fallback)` to `System default ({{language}}` (e.g. `System default (English)`) [discussed/approved with Karoline+Joe]

 **Before**
![before_appearance](https://github.com/dhis2/settings-app/assets/18490902/3ab40a6d-a302-4e2c-bdb1-3852f87a5c85)


**After**
![after_appearance](https://github.com/dhis2/settings-app/assets/18490902/1bba0044-9fd3-4376-8d4e-5a2dc0e7367e)

