### PR TITLE
fix: extend container height [DHIS2-15875]

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,6 +1,7 @@
 .contentWrap {
     display: flex;
     background: var(--colors-grey100);
+    min-height: calc(100vh - 48px); /* subtract header bar height */
 }
 
 .contentArea {


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15875

**Before:**
<img width="1406" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/f28f90e5-e44c-47fe-bfc9-f43757cb1b9e">


**After:**
<img width="1409" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/7bed0065-00ea-4d79-9687-dfab8c1343ff">

_Note:_ I thought that just setting the height to 100% should work here, but that did not. Maybe because of something related to existing material ui theme? Hence, I went with 100vh - header bar height, which did work.