### PR TITLE
fix: update info icons

### DIFF
--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -1,8 +1,14 @@
 import i18n from '@dhis2/d2-i18n'
-import { Button, Card, CenteredContent, CircularLoader } from '@dhis2/ui'
+import {
+    Button,
+    Card,
+    CenteredContent,
+    CircularLoader,
+    IconInfo24,
+    Tooltip,
+} from '@dhis2/ui'
 import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component.js'
 import { wordToValidatorMap } from 'd2-ui/lib/forms/Validators.js'
-import IconButton from 'material-ui/IconButton'
 import PropTypes from 'prop-types'
 import React from 'react'
 import configOptionStore from './configOptionStore.js'
@@ -35,7 +41,7 @@ const styles = {
         color: AppTheme.rawTheme.palette.primary1Color,
         position: 'absolute',
         right: 0,
-        top: 24,
+        top: 36,
     },
     menuIcon: {
         color: '#757575',
@@ -84,24 +90,12 @@ function wrapUserSettingsOverride({ component, valueLabel }) {
                 : i18n.t('This setting can be overridden by user settings')
 
             return (
-                <div style={{ marginRight: 48 }}>
+                <div style={{ marginRight: 36 }}>
                     {super.render()}
                     <div style={labelStyle}>
-                        <IconButton
-                            iconClassName="material-icons"
-                            tooltip={labelText}
-                            tooltipPosition="bottom-left"
-                            iconStyle={{
-                                color: AppTheme.rawTheme.palette.primary1Color,
-                            }}
-                            tooltipStyles={{
-                                fontSize: '.75rem',
-                                marginRight: 32,
-                                marginTop: -32,
-                            }}
-                        >
-                            info_outline
-                        </IconButton>
+                        <Tooltip content={labelText}>
+                            <IconInfo24 />
+                        </Tooltip>
                     </div>
                 </div>
             )


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-10834

This updates the information icons so that they are not using a button. I've also updated to use our own Tooltip component and have lightly updated the existing CSS to get them in alignment (I did not want to do more comprehensive CSS updates, so this is a bit eyeballed)

**Before**
<img width="881" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/2b0f34f8-512d-4bc8-82c3-1a4f0d280d64">


**After**
<img width="890" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/db10f182-ae8c-40fc-9cec-6afb2f1232e8">
