### PR TITLE
chore: update allow list language [DHIS2-10247]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-08-24T10:48:48.806Z\n"
-"PO-Revision-Date: 2023-08-24T10:48:48.806Z\n"
+"POT-Creation-Date: 2023-12-15T15:25:33.200Z\n"
+"PO-Revision-Date: 2023-12-15T15:25:33.200Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -89,84 +89,6 @@ msgstr "Don't sync metadata if DHIS versions differ"
 msgid "Metadata Versioning"
 msgstr "Metadata Versioning"
 
-msgid "This client ID is already taken"
-msgstr "This client ID is already taken"
-
-msgid "Name"
-msgstr "Name"
-
-msgid "Required"
-msgstr "Required"
-
-msgid "Client ID"
-msgstr "Client ID"
-
-msgid "Client Secret"
-msgstr "Client Secret"
-
-msgid "Grant Types"
-msgstr "Grant Types"
-
-msgid "Password"
-msgstr "Password"
-
-msgid "Refresh token"
-msgstr "Refresh token"
-
-msgid "Authorization code"
-msgstr "Authorization code"
-
-msgid "One URL per line"
-msgstr "One URL per line"
-
-msgid "Redirect URIs"
-msgstr "Redirect URIs"
-
-msgid "This field should contain a list of URLs"
-msgstr "This field should contain a list of URLs"
-
-msgid "Create new OAuth2 Client"
-msgstr "Create new OAuth2 Client"
-
-msgid "Edit OAuth2 Client"
-msgstr "Edit OAuth2 Client"
-
-msgid "Save"
-msgstr "Save"
-
-msgid "Cancel"
-msgstr "Cancel"
-
-msgid "There are currently no OAuth2 clients registered"
-msgstr "There are currently no OAuth2 clients registered"
-
-msgid "Edit"
-msgstr "Edit"
-
-msgid "Delete"
-msgstr "Delete"
-
-msgid "OAuth2 client saved"
-msgstr "OAuth2 client saved"
-
-msgid "Failed to save OAuth2 client"
-msgstr "Failed to save OAuth2 client"
-
-msgid "Add OAuth2 client"
-msgstr "Add OAuth2 client"
-
-msgid "Yes"
-msgstr "Yes"
-
-msgid "No"
-msgstr "No"
-
-msgid "OAuth2 client deleted"
-msgstr "OAuth2 client deleted"
-
-msgid "Failed to delete OAuth2 client"
-msgstr "Failed to delete OAuth2 client"
-
 msgid "Settings updated"
 msgstr "Settings updated"
 
@@ -224,14 +146,14 @@ msgstr "Synchronization"
 msgid "Synchronization settings"
 msgstr "Synchronization settings"
 
-msgid "OAuth2 Clients"
-msgstr "OAuth2 Clients"
-
 msgid "This field is required"
 msgstr "This field is required"
 
 msgid "This field should be a URL"
 msgstr "This field should be a URL"
+
+msgid "This field should contain a list of URLs"
+msgstr "This field should contain a list of URLs"
 
 msgid "This field should be a number"
 msgstr "This field should be a number"
@@ -632,6 +554,9 @@ msgstr "Database language"
 msgid "Property to display in analysis modules"
 msgstr "Property to display in analysis modules"
 
+msgid "Name"
+msgstr "Name"
+
 msgid "Short name"
 msgstr "Short name"
 
@@ -673,6 +598,9 @@ msgstr "Port"
 
 msgid "Username"
 msgstr "Username"
+
+msgid "Password"
+msgstr "Password"
 
 msgid "TLS"
 msgstr "TLS"
@@ -734,8 +662,11 @@ msgstr "Number of days before password expiry to send reminder (1–28)"
 msgid "Minimum characters in password"
 msgstr "Minimum characters in password"
 
-msgid "CORS whitelist"
-msgstr "CORS whitelist"
+msgid "CORS allowlist"
+msgstr "CORS allowlist"
+
+msgid "One URL per line"
+msgstr "One URL per line"
 
 msgid "reCAPTCHA Site Key"
 msgstr "reCAPTCHA Site Key"
@@ -781,6 +712,9 @@ msgstr ""
 "Changing your calendar setting after you have entered data can make your "
 "system unusable. If you have entered data, it is strongly recommended that "
 "you do not change your calendar setting."
+
+msgid "Cancel"
+msgstr "Cancel"
 
 msgid "Yes, change calendar"
 msgstr "Yes, change calendar"

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -585,7 +585,7 @@ const settingsKeyMapping = {
         },
     },
     corsWhitelist: {
-        label: i18n.t('CORS whitelist'),
+        label: i18n.t('CORS allowlist'),
         configuration: true,
         multiLine: true,
         hintText: i18n.t('One URL per line'),


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-10247

This PR updates the label for the corsAllowlist / corsWhitelist items:
<img width="641" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/0beb1ce5-21ea-4897-8253-20c65c482bf0">

Note that while the corsAllowlist now is available from api/configurations and an alias exists for POST to api/configurations/corsAllowist, I have not changed to use these updated api endpoints because unfortunately, this app uses logic that is in d2 to transform the corsWhitelist field to the appropriate payload (https://github.com/dhis2/d2/blob/master/src/system/SystemConfiguration.js#L78). I don't think it is worth updating the d2 dependency at the moment given that api/configuration/corsWhitelist is still maintained and given that we want to overhaul settings app anyway (at which point I assume we will get rid of the dependency to d2)