### PR TITLE
fix: remove keyAnalyticsMaintenanceMode [DHIS2-16534]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-01-19T12:30:16.705Z\n"
-"PO-Revision-Date: 2024-01-19T12:30:16.705Z\n"
+"POT-Creation-Date: 2024-01-23T20:33:57.618Z\n"
+"PO-Revision-Date: 2024-01-23T20:33:57.618Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -463,9 +463,6 @@ msgstr "Last 9 years"
 
 msgid "Respect category option start and end date in analytics table export"
 msgstr "Respect category option start and end date in analytics table export"
-
-msgid "Put analytics in maintenance mode"
-msgstr "Put analytics in maintenance mode"
 
 msgid "Include zero data values in analytics tables"
 msgstr "Include zero data values in analytics tables"

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -55,7 +55,6 @@ export const categories = {
             'keyAnalyticsCacheProgressiveTtlFactor',
             'keyIgnoreAnalyticsApprovalYearThreshold',
             'keyRespectMetaDataStartEndDatesInAnalyticsTableExport',
-            'keyAnalyticsMaintenanceMode',
             'keyIncludeZeroValuesInAnalytics',
             'keyDashboardContextMenuItemSwitchViewType',
             'keyDashboardContextMenuItemOpenInRelevantApp',

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -248,10 +248,6 @@ const settingsKeyMapping = {
         ),
         type: 'checkbox',
     },
-    keyAnalyticsMaintenanceMode: {
-        label: i18n.t('Put analytics in maintenance mode'),
-        type: 'checkbox',
-    },
     keyIncludeZeroValuesInAnalytics: {
         label: i18n.t('Include zero data values in analytics tables'),
         type: 'checkbox',


### PR DESCRIPTION
This PR removes keyAnalyticsMaintenanceMode (under analytics section) as it is no longer supported from v40 onwards.

**Before**
<img width="849" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/d3f97a4a-2b81-4ce8-9085-782931741d52">


**After**
<img width="830" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/99f86836-381d-41f5-a1a0-bd55e73f1605">
