### PR TITLE
chore: set minDHIS2Version

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -3,6 +3,7 @@ const config = {
     name: 'settings',
     title: 'Settings',
     coreApp: true,
+    minDHIS2Version: '2.41',
 
     entryPoints: {
         app: './src/App.js',


### PR DESCRIPTION
set minDHIS2Version in config. (Required for migration to continuous release)