### PR TITLE
feat(DHIS2-16944): add login page settings

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -94,6 +94,8 @@ export const categories = {
             'keyRequireAddToView',
             'keyUseCustomLogoFront',
             'keyUseCustomLogoBanner',
+            'loginPageLayout',
+            'loginPageTemplate',
         ],
     },
     email: {

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -323,6 +323,7 @@ class SettingsFields extends React.Component {
                         min: mapping.minValue,
                         max: mapping.maxValue,
                         helpText: mapping.helpText,
+                        rowsMax: mapping.rowsMax,
                     },
                     validators,
                 }

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -438,6 +438,20 @@ const settingsKeyMapping = {
         label: i18n.t('Require authority to add to view object lists'),
         type: 'checkbox',
     },
+    loginPageLayout: {
+        label: i18n.t('Login page theme'),
+        type: 'dropdown',
+        options: {
+            DEFAULT: i18n.t('Default'),
+            SIDEBAR: i18n.t('Sidebar'),
+            CUSTOM: i18n.t('Custom'),
+        },
+    },
+    loginPageTemplate: {
+        label: i18n.t('Login page template'),
+        multiLine: true,
+        rowsMax: 10,
+    },
     keyUseCustomLogoFront: {
         label: i18n.t('Custom login page logo'),
         type: 'staticContent',


### PR DESCRIPTION
The MMVP for this functionality:
- @cooper-joe are you ok with the second HTML input for the HTML template? We're not uploading a file somewhere, this is just an HTML that's saved in the settings so needs to be in a text box.
- what placeholder text should we have?
![image](https://github.com/dhis2/settings-app/assets/1014725/28c750f7-65ea-4f84-a2f1-894387682a65)

![image](https://github.com/dhis2/settings-app/assets/1014725/60666a16-64c7-4cdf-bdef-be7af229d4f8)
