### PR TITLE
fix: show a generic error when updating setting fails

### DIFF
--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -27,6 +27,11 @@ const saveLocalizedAppearanceSetting = (d2, key, value, locale) => {
             settingsActions.showSnackbarMessage(i18n.t('Settings updated'))
         })
         .catch((err) => {
+            settingsActions.showSnackbarMessage(
+                i18n.t(
+                    'There was a problem updating settings. Changes have not been saved.'
+                )
+            )
             console.error('Failed to save localized setting:', err)
         })
 }
@@ -38,6 +43,11 @@ const saveConfiguration = (d2, key, value) =>
             settingsActions.showSnackbarMessage(i18n.t('Settings updated'))
         })
         .catch((err) => {
+            settingsActions.showSnackbarMessage(
+                i18n.t(
+                    'There was a problem updating settings. Changes have not been saved.'
+                )
+            )
             console.error('Failed to save configuration:', err)
         })
 
@@ -48,6 +58,11 @@ const saveSetting = (d2, key, value) =>
             settingsActions.showSnackbarMessage(i18n.t('Settings updated'))
         })
         .catch((err) => {
+            settingsActions.showSnackbarMessage(
+                i18n.t(
+                    'There was a problem updating settings. Changes have not been saved.'
+                )
+            )
             console.error('Failed to save setting:', err)
         })
 


### PR DESCRIPTION
Right now, when something goes wrong trying to update a setting (wrong permission, missing key...), the app fails silently. This adds a a generic error message (approved by Joe) until we will revisit this again to improve the design and messaging (to try to display the exact error).