### PR TITLE
fix: update app name to match the bundled apps in core

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,7 +1,7 @@
 const config = {
     id: '4f6eab1a-29ac-4f7a-b74c-8ba95ea7df49',
     type: 'app',
-    name: 'System Settings',
+    name: 'settings',
     title: 'System Settings',
     coreApp: true,
     minDHIS2Version: '2.41',


### PR DESCRIPTION
the app name needs to match [the name maintained](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java#L70) in DHIS2 core for bundled core apps.