### PR TITLE
feat: remove oauth2 from version 42 and above

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-02-09T16:13:02.251Z\n"
-"PO-Revision-Date: 2024-02-09T16:13:02.251Z\n"
+"POT-Creation-Date: 2024-06-28T11:48:52.681Z\n"
+"PO-Revision-Date: 2024-06-28T11:48:52.681Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -89,8 +89,89 @@ msgstr "Don't sync metadata if DHIS versions differ"
 msgid "Metadata Versioning"
 msgstr "Metadata Versioning"
 
+msgid "This client ID is already taken"
+msgstr "This client ID is already taken"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Required"
+msgstr "Required"
+
+msgid "Client ID"
+msgstr "Client ID"
+
+msgid "Client Secret"
+msgstr "Client Secret"
+
+msgid "Grant Types"
+msgstr "Grant Types"
+
+msgid "Password"
+msgstr "Password"
+
+msgid "Refresh token"
+msgstr "Refresh token"
+
+msgid "Authorization code"
+msgstr "Authorization code"
+
+msgid "One URL per line"
+msgstr "One URL per line"
+
+msgid "Redirect URIs"
+msgstr "Redirect URIs"
+
+msgid "This field should contain a list of URLs"
+msgstr "This field should contain a list of URLs"
+
+msgid "Create new OAuth2 Client"
+msgstr "Create new OAuth2 Client"
+
+msgid "Edit OAuth2 Client"
+msgstr "Edit OAuth2 Client"
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Cancel"
+msgstr "Cancel"
+
+msgid "There are currently no OAuth2 clients registered"
+msgstr "There are currently no OAuth2 clients registered"
+
+msgid "Edit"
+msgstr "Edit"
+
+msgid "Delete"
+msgstr "Delete"
+
+msgid "OAuth2 client saved"
+msgstr "OAuth2 client saved"
+
+msgid "Failed to save OAuth2 client"
+msgstr "Failed to save OAuth2 client"
+
+msgid "Add OAuth2 client"
+msgstr "Add OAuth2 client"
+
+msgid "Yes"
+msgstr "Yes"
+
+msgid "No"
+msgstr "No"
+
+msgid "OAuth2 client deleted"
+msgstr "OAuth2 client deleted"
+
+msgid "Failed to delete OAuth2 client"
+msgstr "Failed to delete OAuth2 client"
+
 msgid "Settings updated"
 msgstr "Settings updated"
+
+msgid "There was a problem updating settings. Changes have not been saved."
+msgstr "There was a problem updating settings. Changes have not been saved."
 
 msgid "General"
 msgstr "General"
@@ -146,20 +227,17 @@ msgstr "Synchronization"
 msgid "Synchronization settings"
 msgstr "Synchronization settings"
 
-msgid "OAuth2 Clients"
-msgstr "OAuth2 Clients"
-
 msgid "Scheduled jobs"
 msgstr "Scheduled jobs"
+
+msgid "OAuth2 Clients"
+msgstr "OAuth2 Clients"
 
 msgid "This field is required"
 msgstr "This field is required"
 
 msgid "This field should be a URL"
 msgstr "This field should be a URL"
-
-msgid "This field should contain a list of URLs"
-msgstr "This field should contain a list of URLs"
 
 msgid "This field should be a number"
 msgstr "This field should be a number"
@@ -557,9 +635,6 @@ msgstr "Database language"
 msgid "Property to display in analysis modules"
 msgstr "Property to display in analysis modules"
 
-msgid "Name"
-msgstr "Name"
-
 msgid "Short name"
 msgstr "Short name"
 
@@ -574,6 +649,21 @@ msgstr "Comma"
 
 msgid "Require authority to add to view object lists"
 msgstr "Require authority to add to view object lists"
+
+msgid "Login page theme"
+msgstr "Login page theme"
+
+msgid "Default"
+msgstr "Default"
+
+msgid "Sidebar"
+msgstr "Sidebar"
+
+msgid "Custom"
+msgstr "Custom"
+
+msgid "Login page template"
+msgstr "Login page template"
 
 msgid "Custom login page logo"
 msgstr "Custom login page logo"
@@ -601,9 +691,6 @@ msgstr "Port"
 
 msgid "Username"
 msgstr "Username"
-
-msgid "Password"
-msgstr "Password"
 
 msgid "TLS"
 msgstr "TLS"
@@ -668,9 +755,6 @@ msgstr "Minimum characters in password"
 msgid "CORS allowlist"
 msgstr "CORS allowlist"
 
-msgid "One URL per line"
-msgstr "One URL per line"
-
 msgid "reCAPTCHA Site Key"
 msgstr "reCAPTCHA Site Key"
 
@@ -715,9 +799,6 @@ msgstr ""
 "Changing your calendar setting after you have entered data can make your "
 "system unusable. If you have entered data, it is strongly recommended that "
 "you do not change your calendar setting."
-
-msgid "Cancel"
-msgstr "Cancel"
 
 msgid "Yes, change calendar"
 msgstr "Yes, change calendar"

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useDataQuery } from '@dhis2/app-runtime'
+import { useDataQuery, useConfig } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { CssVariables, CenteredContent, CircularLoader } from '@dhis2/ui'
 import React from 'react'
@@ -98,6 +98,7 @@ const query = {
 
 const AppWrapper = () => {
     const { d2 } = useD2()
+    const { apiVersion } = useConfig()
     const { loading, error, data } = useDataQuery(query)
 
     if (error) {
@@ -191,7 +192,7 @@ const AppWrapper = () => {
     return (
         <>
             <CssVariables spacers colors />
-            <App d2={d2} />
+            <App d2={d2} apiVersion={apiVersion} />
         </>
     )
 }

--- a/src/app.component.js
+++ b/src/app.component.js
@@ -100,13 +100,13 @@ class AppComponent extends React.Component {
         const filteredCategoryOrder = categoryOrder.filter(
             (category) =>
                 !categories[category].maximumApiVersion ||
-                apiVersion > categories[category].maximumApiVersion
+                apiVersion <= categories[category].maximumApiVersion
         )
         const filteredCategories = Object.fromEntries(
             Object.entries(categories).filter(
                 ([key]) =>
                     !categories[key].maximumApiVersion ||
-                    apiVersion > categories[key].maximumApiVersion
+                    apiVersion <= categories[key].maximumApiVersion
             )
         )
 
@@ -125,13 +125,7 @@ class AppComponent extends React.Component {
                 const search = decodeURIComponent(location.search.substr(1))
                 this.doSearch(search)
             } else if (Object.keys(filteredCategories).includes(section)) {
-                // settingsActions.setCategory(section)
-                if (this.props.apiVersion > 40 && section === 'oauth2') {
-                    this.history.replace(`/${filteredCategoryOrder[0]}`)
-                    settingsActions.setCategory(filteredCategoryOrder[0])
-                } else {
-                    settingsActions.setCategory(section)
-                }
+                settingsActions.setCategory(section)
             } else {
                 this.history.replace(`/${filteredCategoryOrder[0]}`)
                 settingsActions.setCategory(filteredCategoryOrder[0])

--- a/src/app.component.js
+++ b/src/app.component.js
@@ -202,8 +202,8 @@ class AppComponent extends React.Component {
 }
 
 AppComponent.propTypes = {
-    d2: PropTypes.object.isRequired,
     apiVersion: PropTypes.number.isRequired,
+    d2: PropTypes.object.isRequired,
 }
 AppComponent.contextTypes = { muiTheme: PropTypes.object }
 AppComponent.childContextTypes = {

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -181,5 +181,6 @@ export const categories = {
         pageLabel: i18n.t('OAuth2 Clients'),
         authority: 'F_OAUTH2_CLIENT_MANAGE',
         settings: ['oauth2clients'],
+        maximumApiVersion: 41,
     },
 }


### PR DESCRIPTION
Implements [DHIS2-17592](https://dhis2.atlassian.net/browse/DHIS2-17592)
---

### Description
 conditional exclusion of the OAuth2 category in the DHIS2 settings app based on the API version. Specifically, the OAuth2 category is hidden and inaccessible when the API version is greater than 41. This change ensures that users do not see or interact with the OAuth2 settings when using versions over 41 of the DHIS2 API.

---

### Screenshots
When API version is 41 or below (OAuth2 category visible)
<img width="1440" alt="Screenshot 2024-06-28 at 13 18 45" src="https://github.com/dhis2/settings-app/assets/87203527/1608555c-01eb-4856-b17d-09922fc9e12d">
In this screenshot, the OAuth2 category is visible because the API version is 41 or below.

When API version is above 41 (OAuth2 category hidden)
<img width="1440" alt="Screenshot 2024-06-28 at 13 19 07" src="https://github.com/dhis2/settings-app/assets/87203527/cdf23c09-ee2f-41a8-b409-800ae9f24d6c">
In this screenshot, the OAuth2 category is hidden because the API version is above 41. Additionally, attempting to manually navigate to the OAuth2 page in the browser will redirect you to the general settings page, ensuring users cannot access the hidden category.





[DHIS2-17592]: https://dhis2.atlassian.net/browse/DHIS2-17592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ