### PR TITLE
fix: pass valid locale for number formatting [DHIS2-17709]

### DIFF
--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -4,8 +4,15 @@ const canBeOverridenLabel = i18n.t(
     'This setting can be overridden by user settings'
 )
 
+const parseLocale = (localeString) => {
+    const [language, country] = (localeString ?? 'en').split(/[-_]/)
+    return `${language}${country ? `-${country}` : ''}`
+}
+
+const parsedLocale = parseLocale(i18n.language)
+
 const formatNumber = (value) =>
-    new Intl.NumberFormat(i18n.language).format(value)
+    new Intl.NumberFormat(parsedLocale).format(value)
 
 /**
  * This file provides information about DHIS2 system settings and configuration options that are not otherwise


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17709

**Before**
<img width="877" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/e6d7e89d-e21a-46c3-939b-c80b2729571e">

**After**
<img width="742" alt="image" src="https://github.com/dhis2/settings-app/assets/18490902/eb9244f9-2944-4f4d-9b7f-f056ec76f18f">


### Tests
**Automated**: The app has no automated tests, so I'm not adding any with this PR 🤠
**Manual**: Tested app with various languages. Because of the existing logic of the number formatting, it is only applied on some number and there are some surprising variations:
- variants of Arabic (e.g. `Arabic (Sudan)`) return Arabic formatted numbers (e.g. `٢٠٠٬٠٠٠` instead of `200,000`), but Arabic itself returns `200,000`. I checked with Alaa and she said in Sudan, they're used interchangeably; in Egypt people prefer `٢٠٠٬٠٠٠`)
- Bangla returns with Bengali numerals. (not sure if this is expected or not, and I don't know of Bengali speakers to ask for confirmation.
In both cases, I think it's probably okay to leave with what we have here, rather than make (additional) arbitrary exceptions.

also manually tested the `parseLocale` function that was added to return `language-locale`, e.g. some results:

```
> parseLocale(undefined)
'en'
> parseLocale(null)
'en'
> parseLocale('pt_BR')
'pt-BR'
> parseLocale('tet')
'tet'
> parseLocale('pt-BR-Cyrl')
'pt-BR'
> parseLocale('uz_UZ-Cyrl')
'uz-UZ'
> parseLocale('uz_UZ_Cyrl')
'uz-UZ'
> parseLocale('fr')
'fr'
```