### PR TITLE
feat: add keyEmbeddedDashboardsEnabled [DHIS2-18472]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-06-28T11:48:52.681Z\n"
-"PO-Revision-Date: 2024-06-28T11:48:52.681Z\n"
+"POT-Creation-Date: 2024-11-27T12:04:49.662Z\n"
+"PO-Revision-Date: 2024-11-27T12:04:49.662Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -547,6 +547,9 @@ msgstr "Respect category option start and end date in analytics table export"
 
 msgid "Include zero data values in analytics tables"
 msgstr "Include zero data values in analytics tables"
+
+msgid "Enable embedded dashboards"
+msgstr "Enable embedded dashboards"
 
 msgid "Caching factor"
 msgstr "Caching factor"

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -57,6 +57,7 @@ export const categories = {
             'keyIgnoreAnalyticsApprovalYearThreshold',
             'keyRespectMetaDataStartEndDatesInAnalyticsTableExport',
             'keyIncludeZeroValuesInAnalytics',
+            'keyEmbeddedDashboardsEnabled',
             'keyDashboardContextMenuItemSwitchViewType',
             'keyDashboardContextMenuItemOpenInRelevantApp',
             'keyDashboardContextMenuItemShowInterpretationsAndDetails',

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -20,20 +20,48 @@ export const categories = {
         icon: 'settings',
         pageLabel: i18n.t('General settings'),
         settings: [
-            'keyAnalyticsMaxLimit',
-            'keySqlViewMaxLimit',
-            'infrastructuralIndicators',
-            'infrastructuralDataElements',
-            'infrastructuralPeriodType',
-            'feedbackRecipients',
-            'systemUpdateNotificationRecipients',
-            'offlineOrganisationUnitLevel',
-            'factorDeviation',
-            'phoneNumberAreaCode',
-            'multiOrganisationUnitForms',
-            'keyAcceptanceRequiredForApproval',
-            'keyGatherAnalyticalObjectStatisticsInDashboardViews',
-            'keyCountPassiveDashboardViewsInUsageAnalytics',
+            {
+                setting: 'keyAnalyticsMaxLimit',
+            },
+            {
+                setting: 'keySqlViewMaxLimit',
+            },
+            {
+                setting: 'infrastructuralIndicators',
+            },
+            {
+                setting: 'infrastructuralDataElements',
+            },
+            {
+                setting: 'infrastructuralPeriodType',
+            },
+            {
+                setting: 'feedbackRecipients',
+            },
+            {
+                setting: 'systemUpdateNotificationRecipients',
+            },
+            {
+                setting: 'offlineOrganisationUnitLevel',
+            },
+            {
+                setting: 'factorDeviation',
+            },
+            {
+                setting: 'phoneNumberAreaCode',
+            },
+            {
+                setting: 'multiOrganisationUnitForms',
+            },
+            {
+                setting: 'keyAcceptanceRequiredForApproval',
+            },
+            {
+                setting: 'keyGatherAnalyticalObjectStatisticsInDashboardViews',
+            },
+            {
+                setting: 'keyCountPassiveDashboardViewsInUsageAnalytics',
+            },
         ],
     },
     analytics: {
@@ -41,30 +69,81 @@ export const categories = {
         icon: 'equalizer',
         pageLabel: i18n.t('Analytics settings'),
         settings: [
-            'keyAnalysisRelativePeriod',
-            'keyAnalysisDisplayProperty',
-            'keyAnalysisDigitGroupSeparator',
-            'keyHideDailyPeriods',
-            'keyHideWeeklyPeriods',
-            'keyHideBiWeeklyPeriods',
-            'keyHideMonthlyPeriods',
-            'keyHideBiMonthlyPeriods',
-            'analyticsFinancialYearStart',
-            'keyCacheStrategy',
-            'keyCacheability',
-            'keyAnalyticsCacheTtlMode',
-            'keyAnalyticsCacheProgressiveTtlFactor',
-            'keyIgnoreAnalyticsApprovalYearThreshold',
-            'keyRespectMetaDataStartEndDatesInAnalyticsTableExport',
-            'keyIncludeZeroValuesInAnalytics',
-            'keyEmbeddedDashboardsEnabled',
-            'keyDashboardContextMenuItemSwitchViewType',
-            'keyDashboardContextMenuItemOpenInRelevantApp',
-            'keyDashboardContextMenuItemShowInterpretationsAndDetails',
-            'keyDashboardContextMenuItemViewFullscreen',
-            'facilityOrgUnitGroupSet',
-            'facilityOrgUnitLevel',
-            'keyDefaultBaseMap',
+            {
+                setting: 'keyAnalysisRelativePeriod',
+            },
+            {
+                setting: 'keyAnalysisDisplayProperty',
+            },
+            {
+                setting: 'keyAnalysisDigitGroupSeparator',
+            },
+            {
+                setting: 'keyHideDailyPeriods',
+            },
+            {
+                setting: 'keyHideWeeklyPeriods',
+            },
+            {
+                setting: 'keyHideBiWeeklyPeriods',
+            },
+            {
+                setting: 'keyHideMonthlyPeriods',
+            },
+            {
+                setting: 'keyHideBiMonthlyPeriods',
+            },
+            {
+                setting: 'analyticsFinancialYearStart',
+            },
+            {
+                setting: 'keyCacheStrategy',
+            },
+            {
+                setting: 'keyCacheability',
+            },
+            {
+                setting: 'keyAnalyticsCacheTtlMode',
+            },
+            {
+                setting: 'keyAnalyticsCacheProgressiveTtlFactor',
+            },
+            {
+                setting: 'keyIgnoreAnalyticsApprovalYearThreshold',
+            },
+            {
+                setting:
+                    'keyRespectMetaDataStartEndDatesInAnalyticsTableExport',
+            },
+            {
+                setting: 'keyIncludeZeroValuesInAnalytics',
+            },
+            {
+                setting: 'keyEmbeddedDashboardsEnabled',
+                minimumApiVersion: 42,
+            },
+            {
+                setting: 'keyDashboardContextMenuItemSwitchViewType',
+            },
+            {
+                setting: 'keyDashboardContextMenuItemOpenInRelevantApp',
+            },
+            {
+                setting:
+                    'keyDashboardContextMenuItemShowInterpretationsAndDetails',
+            },
+            {
+                setting: 'keyDashboardContextMenuItemViewFullscreen',
+            },
+            {
+                setting: 'facilityOrgUnitGroupSet',
+            },
+            {
+                setting: 'facilityOrgUnitLevel',
+            },
+            {
+                setting: 'keyDefaultBaseMap',
+            },
         ],
     },
     server: {
@@ -72,11 +151,21 @@ export const categories = {
         icon: 'business',
         pageLabel: i18n.t('Server settings'),
         settings: [
-            'keyDatabaseServerCpus',
-            'keySystemNotificationsEmail',
-            'googleAnalyticsUA',
-            'keyGoogleMapsApiKey',
-            'keyBingMapsApiKey',
+            {
+                setting: 'keyDatabaseServerCpus',
+            },
+            {
+                setting: 'keySystemNotificationsEmail',
+            },
+            {
+                setting: 'googleAnalyticsUA',
+            },
+            {
+                setting: 'keyGoogleMapsApiKey',
+            },
+            {
+                setting: 'keyBingMapsApiKey',
+            },
         ],
     },
     appearance: {
@@ -84,19 +173,45 @@ export const categories = {
         icon: 'looks',
         pageLabel: i18n.t('Appearance settings'),
         settings: [
-            'localizedText',
-            'keyStyle',
-            'startModule',
-            'startModuleEnableLightweight',
-            'helpPageLink',
-            'keyFlag',
-            'keyUiLocale',
-            'keyDbLocale',
-            'keyRequireAddToView',
-            'keyUseCustomLogoFront',
-            'keyUseCustomLogoBanner',
-            'loginPageLayout',
-            'loginPageTemplate',
+            {
+                setting: 'localizedText',
+            },
+            {
+                setting: 'keyStyle',
+            },
+            {
+                setting: 'startModule',
+            },
+            {
+                setting: 'startModuleEnableLightweight',
+            },
+            {
+                setting: 'helpPageLink',
+            },
+            {
+                setting: 'keyFlag',
+            },
+            {
+                setting: 'keyUiLocale',
+            },
+            {
+                setting: 'keyDbLocale',
+            },
+            {
+                setting: 'keyRequireAddToView',
+            },
+            {
+                setting: 'keyUseCustomLogoFront',
+            },
+            {
+                setting: 'keyUseCustomLogoBanner',
+            },
+            {
+                setting: 'loginPageLayout',
+            },
+            {
+                setting: 'loginPageTemplate',
+            },
         ],
     },
     email: {
@@ -104,13 +219,27 @@ export const categories = {
         icon: 'email',
         pageLabel: i18n.t('Email settings'),
         settings: [
-            'keyEmailHostName',
-            'keyEmailPort',
-            'keyEmailUsername',
-            'keyEmailPassword',
-            'keyEmailTls',
-            'keyEmailSender',
-            'emailTestButton',
+            {
+                setting: 'keyEmailHostName',
+            },
+            {
+                setting: 'keyEmailPort',
+            },
+            {
+                setting: 'keyEmailUsername',
+            },
+            {
+                setting: 'keyEmailPassword',
+            },
+            {
+                setting: 'keyEmailTls',
+            },
+            {
+                setting: 'keyEmailSender',
+            },
+            {
+                setting: 'emailTestButton',
+            },
         ],
     },
     access: {
@@ -118,40 +247,89 @@ export const categories = {
         icon: 'lock_open',
         pageLabel: i18n.t('Access settings'),
         settings: [
-            'selfRegistrationRole',
-            'selfRegistrationOrgUnit',
-            'keySelfRegistrationNoRecaptcha',
-            'keyAccountRecovery',
-            'keyLockMultipleFailedLogins',
-            'keyCanGrantOwnUserAuthorityGroups',
-            'keyAllowObjectAssignment',
-            'credentialsExpires',
-            'credentialsExpiryAlert',
-            'credentialsExpiresReminderInDays',
-            'minPasswordLength',
-            'corsWhitelist',
-            'recaptchaSite',
-            'recaptchaSecret',
+            {
+                setting: 'selfRegistrationRole',
+            },
+            {
+                setting: 'selfRegistrationOrgUnit',
+            },
+            {
+                setting: 'keySelfRegistrationNoRecaptcha',
+            },
+            {
+                setting: 'keyAccountRecovery',
+            },
+            {
+                setting: 'keyLockMultipleFailedLogins',
+            },
+            {
+                setting: 'keyCanGrantOwnUserAuthorityGroups',
+            },
+            {
+                setting: 'keyAllowObjectAssignment',
+            },
+            {
+                setting: 'credentialsExpires',
+            },
+            {
+                setting: 'credentialsExpiryAlert',
+            },
+            {
+                setting: 'credentialsExpiresReminderInDays',
+            },
+            {
+                setting: 'minPasswordLength',
+            },
+            {
+                setting: 'corsWhitelist',
+            },
+            {
+                setting: 'recaptchaSite',
+            },
+            {
+                setting: 'recaptchaSecret',
+            },
         ],
     },
     calendar: {
         label: i18n.t('Calendar'),
         icon: 'date_range',
         pageLabel: i18n.t('Calendar settings'),
-        settings: ['keyCalendar', 'keyDateFormat'],
+        settings: [
+            {
+                setting: 'keyCalendar',
+            },
+            {
+                setting: 'keyDateFormat',
+            },
+        ],
     },
     import: {
         label: i18n.t('Data Import'),
         icon: 'system_update_alt',
         pageLabel: i18n.t('Data import settings'),
         settings: [
-            'keyDataImportStrictPeriods',
-            'keyDataImportStrictDataElements',
-            'keyDataImportStrictCategoryOptionCombos',
-            'keyDataImportStrictOrganisationUnits',
-            'keyDataImportStrictAttributeOptionCombos',
-            'keyDataImportRequireCategoryOptionCombo',
-            'keyDataImportRequireAttributeOptionCombo',
+            {
+                setting: 'keyDataImportStrictPeriods',
+            },
+            {
+                setting: 'keyDataImportStrictDataElements',
+            },
+            {
+                setting: 'keyDataImportStrictCategoryOptionCombos',
+            },
+            {
+                setting: 'keyDataImportStrictOrganisationUnits',
+            },
+            {
+                setting: 'keyDataImportStrictAttributeOptionCombos',
+            },
+            {
+                setting: 'keyDataImportRequireCategoryOptionCombo',
+            },
+            {
+                setting: 'keyDataImportRequireAttributeOptionCombo',
+            },
         ],
     },
     sync: {
@@ -159,10 +337,18 @@ export const categories = {
         icon: 'sync',
         pageLabel: i18n.t('Synchronization settings'),
         settings: [
-            'keyRemoteInstanceUrl',
-            'keyRemoteInstanceUsername',
-            'keyRemoteInstancePassword',
-            'keyMetadataDataVersioning',
+            {
+                setting: 'keyRemoteInstanceUrl',
+            },
+            {
+                setting: 'keyRemoteInstanceUsername',
+            },
+            {
+                setting: 'keyRemoteInstancePassword',
+            },
+            {
+                setting: 'keyMetadataDataVersioning',
+            },
         ],
     },
     scheduledJobs: {
@@ -170,10 +356,18 @@ export const categories = {
         icon: 'schedule',
         pageLabel: i18n.t('Scheduled jobs'),
         settings: [
-            'jobsRescheduleAfterMinutes',
-            'jobsCleanupAfterMinutes',
-            'jobsMaxCronDelayHours',
-            'jobsLogDebugBelowSeconds',
+            {
+                setting: 'jobsRescheduleAfterMinutes',
+            },
+            {
+                setting: 'jobsCleanupAfterMinutes',
+            },
+            {
+                setting: 'jobsMaxCronDelayHours',
+            },
+            {
+                setting: 'jobsLogDebugBelowSeconds',
+            },
         ],
     },
     oauth2: {
@@ -181,7 +375,71 @@ export const categories = {
         icon: 'vpn_lock',
         pageLabel: i18n.t('OAuth2 Clients'),
         authority: 'F_OAUTH2_CLIENT_MANAGE',
-        settings: ['oauth2clients'],
+        settings: [
+            {
+                setting: 'oauth2clients',
+            },
+        ],
         maximumApiVersion: 41,
     },
 }
+
+export const filterSettingsByApiVersion = ({ settings, apiVersion }) =>
+    settings
+        .filter((setting) => {
+            // return true unless minimum/maximum version is specified and is out of range
+            if (
+                setting.minimumApiVersion &&
+                apiVersion < setting.minimumApiVersion
+            ) {
+                return false
+            }
+            if (
+                setting.maximumApiVersion &&
+                apiVersion > setting.maximumApiVersion
+            ) {
+                return false
+            }
+            return true
+        })
+        .map((setting) => setting.setting)
+
+export const filterCategoriesByApiVersion = ({ categories, apiVersion }) =>
+    Object.fromEntries(
+        Object.entries(categories).filter(([key]) => {
+            if (
+                categories[key].minimumApiVersion &&
+                apiVersion < categories[key].minimumApiVersion
+            ) {
+                return false
+            }
+            if (
+                categories[key].maximumApiVersion &&
+                apiVersion > categories[key].maximumApiVersion
+            ) {
+                return false
+            }
+            return true
+        })
+    )
+
+export const filterCategoryOrderByApiVersion = ({
+    categoryOrder,
+    categories,
+    apiVersion,
+}) =>
+    categoryOrder.filter((category) => {
+        if (
+            categories?.[category]?.minimumApiVersion &&
+            apiVersion < categories?.[category]?.minimumApiVersion
+        ) {
+            return false
+        }
+        if (
+            categories?.[category]?.maximumApiVersion &&
+            apiVersion > categories?.[category]?.maximumApiVersion
+        ) {
+            return false
+        }
+        return true
+    })

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -259,6 +259,10 @@ const settingsKeyMapping = {
         label: i18n.t('Include zero data values in analytics tables'),
         type: 'checkbox',
     },
+    keyEmbeddedDashboardsEnabled: {
+        label: i18n.t('Enable embedded dashboards'),
+        type: 'checkbox',
+    },
     keyAnalyticsCacheProgressiveTtlFactor: {
         label: i18n.t('Caching factor'),
         type: 'dropdown',


### PR DESCRIPTION
This PR:
- adds the new setting `keyEmbeddedDashboardsEnabled` under Analytics section (see ticket: https://dhis2.atlassian.net/browse/DHIS2-18472)
- adds version control on the settings definitions (this app became continuous release for v41, so previously we have not had to toggle on/off individual settings by version)
- fixes some filtering logic for the search at the category level. For this, I've moved some of the logic for categories filtering by version. We had added a `maximumApiVersion` on the category level to remove oAuth2 after v41, but I noticed when adding the setting-level versioning that the search functionality was not working properly as we also have to filter categories + settings in the search space

I think the approach here is okay. It would be more efficient to just do the filtering once and then set the results in state, or memoize the results rather than performing this filtering both when building the search space and when switching categories. However, I think the filtering operation is fairly trivial as a calculation, and I don't want to refactor more (particularly I think doing so would require reviewing the logic of the search, which seems convoluted).