### PR TITLE
fix: search with feature toggling [DHIS2-18766]

### DIFF
--- a/src/app.component.js
+++ b/src/app.component.js
@@ -25,7 +25,9 @@ class AppComponent extends React.Component {
         this.state = {
             category: categoryOrder[0],
             currentSettings: filterSettingsByApiVersion({
-                settings: categories[categoryOrder[0]].settings,
+                settings: categories[categoryOrder[0]].settings.map(
+                    (s) => s.setting
+                ),
                 apiVersion: props.apiVersion,
             }),
             snackbarMessage: '',

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -239,7 +239,7 @@ settingsActions.searchSettings
     .subscribe((searchResultSettings) => {
         settingsActions.setCategory({
             key: 'search',
-            settings: searchResultSettings,
+            settings: searchResultSettings.map((s) => ({ setting: s })),
             searchTerms,
         })
     })


### PR DESCRIPTION
This fixes a bug with search functionality introduced by https://github.com/dhis2/settings-app/pull/1409 https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18766.

Because PR #1409 changed the format of the categories/settings information (to allow for feature toggling), the search logic also needs some updates so that the arrays used are in consistent format. Without this change, we were getting an inconsistent format when "search category" was selected.

(This would be good to have a test for, but we have no tests in the app, and I don't want to spend the time right now to figure out how to get tests set up with d2)
