### PR TITLE
feat: update enforce verified email checkbox

### DIFF
--- a/src/form-fields/check-box.js
+++ b/src/form-fields/check-box.js
@@ -17,6 +17,7 @@ class Checkbox extends React.Component {
             onChange,
             sectionLabel,
             value,
+            explanatoryText,
             ...other
         } = this.props
         /* eslint-enable no-unused-vars */
@@ -31,6 +32,9 @@ class Checkbox extends React.Component {
                     checked={value === 'true'}
                     {...other}
                 />
+                {explanatoryText && (
+                    <p style={{ fontSize: '12px' }}>{explanatoryText}</p>
+                )}
             </div>
         )
     }
@@ -40,6 +44,7 @@ Checkbox.propTypes = {
     onChange: PropTypes.func.isRequired,
     errorStyle: PropTypes.object,
     errorText: PropTypes.string,
+    explanatoryText: PropTypes.string,
     sectionLabel: PropTypes.string,
     value: PropTypes.string,
 }

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -129,6 +129,12 @@ function getMenuItems(mapping) {
     return optionsMenuItems.concat(sourceMenuItems)
 }
 
+function isEmailConfigured(d2) {
+    const emailHostName = d2.system.settings.settings.keyEmailHostName
+    const emailUserName = d2.system.settings.settings.keyEmailUsername
+    return emailHostName && emailUserName
+}
+
 class SettingsFields extends React.Component {
     componentDidMount() {
         this.subscriptions = []
@@ -189,21 +195,40 @@ class SettingsFields extends React.Component {
                             undefined,
                     }),
                 })
+            case 'checkbox': {
+                const isEmailField = key === 'enforceVerifiedEmail'
+                const emailConfigured = isEmailConfigured(d2)
+                const explanatoryText =
+                    emailConfigured &&
+                    'Settings must be configured to send emails to enforce verified emails'
 
-            case 'checkbox':
+                const commonProps = {
+                    label: fieldBase.props.floatingLabelText,
+                    sectionLabel: mapping.sectionLabel || undefined,
+                    style: fieldBase.props.style,
+                    onCheck: (_event, checked) => {
+                        if (
+                            isEmailField &&
+                            !emailConfigured &&
+                            checked === true
+                        ) {
+                            settingsActions.saveKey(key, 'false')
+                            return
+                        }
+                        settingsActions.saveKey(key, checked ? 'true' : 'false')
+                    },
+
+                    disabled: isEmailField && isEmailField && !emailConfigured,
+                }
+
                 return Object.assign({}, fieldBase, {
                     component: Checkbox,
                     props: {
-                        label: fieldBase.props.floatingLabelText,
-                        sectionLabel:
-                            (mapping.sectionLabel && mapping.sectionLabel) ||
-                            undefined,
-                        style: fieldBase.props.style,
-                        onCheck: (e, v) => {
-                            settingsActions.saveKey(key, v ? 'true' : 'false')
-                        },
+                        ...commonProps,
+                        explanatoryText,
                     },
                 })
+            }
 
             case 'staticContent':
                 return Object.assign({}, fieldBase, {

--- a/src/settingsFields.component.js
+++ b/src/settingsFields.component.js
@@ -198,7 +198,7 @@ class SettingsFields extends React.Component {
             case 'checkbox': {
                 const isEmailField = key === 'enforceVerifiedEmail'
                 const emailConfigured = isEmailConfigured(d2)
-                const explanatoryText =
+                const explanatoryText = isEmailField &&
                     emailConfigured &&
                     'Settings must be configured to send emails to enforce verified emails'
 

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -259,10 +259,6 @@ const settingsKeyMapping = {
         label: i18n.t('Include zero data values in analytics tables'),
         type: 'checkbox',
     },
-    keyEmbeddedDashboardsEnabled: {
-        label: i18n.t('Enable embedded dashboards'),
-        type: 'checkbox',
-    },
     keyAnalyticsCacheProgressiveTtlFactor: {
         label: i18n.t('Caching factor'),
         type: 'dropdown',
@@ -552,14 +548,14 @@ const settingsKeyMapping = {
         label: i18n.t('Enable user account recovery'),
         type: 'checkbox',
     },
-    enforceVerifiedEmail: {
-        label: i18n.t('Enforce verified emails'),
-        type: 'checkbox',
-    },
     keyLockMultipleFailedLogins: {
         label: i18n.t(
             'Lock user account temporarily after multiple failed login attempts'
         ),
+        type: 'checkbox',
+    },
+    enforceVerifiedEmail: {
+        label: i18n.t('Enforce verified emails'),
         type: 'checkbox',
     },
     keyCanGrantOwnUserAuthorityGroups: {


### PR DESCRIPTION
# Implement Email Configuration Check for `enforceVerifiedEmail` Setting [for this issue](https://dhis2.atlassian.net/browse/DHIS2-18789)

## Description:
This PR introduces the following changes to the `SettingsFields` component:

1. **`enforceVerifiedEmail` Setting Email Configuration Check**:
    - The checkbox for `enforceVerifiedEmail` is now conditionally enabled. It can only be checked (set to `true`) if the system has email configuration (`keyEmailHostName` and `keyEmailUserName` are both set).
    - If email settings are missing, the checkbox is disabled, and an explanatory text is displayed to inform the user that email configuration is required for this setting to work.
    - If the email settings are missing, the `enforceVerifiedEmail` setting can only be set to `false`.

2. **Fixing ESLint `no-case-declarations` Errors**:
    - Wrapped the contents of each `switch` case block in curly braces `{}` to resolve ESLint warnings/errors regarding lexical declarations (`const`, `let`, etc.) inside `switch` statements. This ensures proper scoping and avoids the error: `Unexpected lexical declaration in case block`.

## Motivation and Context:
- The purpose of the first change is to ensure that the `enforceVerifiedEmail` setting can only be enabled when email configuration is properly set up, preventing confusion or errors if the email system is not properly configured.

## Changes Made:
- Added a conditional check to enable/disable the `enforceVerifiedEmail` checkbox based on the presence of email configuration (`keyEmailHostName` and `keyEmailUserName`).
- Displayed explanatory text for `enforceVerifiedEmail` to clarify that email configuration is required to enable this setting.
- Adjusted some logic to handle edge cases for settings that require email configuration.
