### PR TITLE
fix: clean up min version globalShellEnabled

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -215,12 +215,8 @@ export const categories = {
             },
             {
                 setting: 'globalShellEnabled',
-                maximumApiVersion: 42,
+                minimumApiVersion: 42,
             },
-            // {
-            //     setting: 'globalShellAppName',
-            //     maximumApiVersion: 42,
-            // },
         ],
     },
     email: {

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -463,11 +463,6 @@ const settingsKeyMapping = {
         label: i18n.t('Enable Global Shell'),
         type: 'checkbox',
     },
-    // globalShellAppName: {
-    //     label: i18n.t('Global Shell App'),
-    //     type: 'dropdown',
-    //     source: 'startModules',
-    // },
     keyUseCustomLogoFront: {
         label: i18n.t('Custom login page logo'),
         type: 'staticContent',


### PR DESCRIPTION
fixes issue to make `globalShellEnabled` property appear in v42+. (https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-19290)

I will follow up with separate PRs to add this to documentation.