### PR TITLE
fix: settings cleanup [DHIS2-19366]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-03-19T09:22:40.114Z\n"
-"PO-Revision-Date: 2025-03-19T09:22:40.115Z\n"
+"POT-Creation-Date: 2025-04-02T12:55:54.216Z\n"
+"PO-Revision-Date: 2025-04-02T12:55:54.216Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -92,23 +92,17 @@ msgstr "Metadata Versioning"
 msgid "This client ID is already taken"
 msgstr "This client ID is already taken"
 
-msgid "Name"
-msgstr "Name"
+msgid "Client ID"
+msgstr "Client ID"
 
 msgid "Required"
 msgstr "Required"
-
-msgid "Client ID"
-msgstr "Client ID"
 
 msgid "Client Secret"
 msgstr "Client Secret"
 
 msgid "Grant Types"
 msgstr "Grant Types"
-
-msgid "Password"
-msgstr "Password"
 
 msgid "Refresh token"
 msgstr "Refresh token"
@@ -166,6 +160,12 @@ msgstr "OAuth2 client deleted"
 
 msgid "Failed to delete OAuth2 client"
 msgstr "Failed to delete OAuth2 client"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Password"
+msgstr "Password"
 
 msgid "Settings updated"
 msgstr "Settings updated"
@@ -281,6 +281,13 @@ msgstr "Unlimited"
 
 msgid "Maximum number of SQL view records"
 msgstr "Maximum number of SQL view records"
+
+msgid ""
+"Maximum number of tracked entity records to fetch from database (enter 0 "
+"for unlimited)"
+msgstr ""
+"Maximum number of tracked entity records to fetch from database (enter 0 "
+"for unlimited)"
 
 msgid "Infrastructural indicators"
 msgstr "Infrastructural indicators"
@@ -677,9 +684,6 @@ msgstr "Login page template"
 
 msgid "Enable Global Shell"
 msgstr "Enable Global Shell"
-
-msgid "Global Shell App"
-msgstr "Global Shell App"
 
 msgid "Custom login page logo"
 msgstr "Custom login page logo"

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -53,6 +53,7 @@ export const categories = {
             },
             {
                 setting: 'multiOrganisationUnitForms',
+                maximumApiVersion: 41,
             },
             {
                 setting: 'keyAcceptanceRequiredForApproval',

--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -28,6 +28,9 @@ export const categories = {
                 setting: 'keySqlViewMaxLimit',
             },
             {
+                setting: 'KeyTrackedEntityMaxLimit',
+            },
+            {
                 setting: 'infrastructuralIndicators',
             },
             {

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -54,6 +54,12 @@ const settingsKeyMapping = {
             1000000: formatNumber(1000000),
         },
     },
+    KeyTrackedEntityMaxLimit: {
+        label: i18n.t(
+            'Maximum number of tracked entity records to fetch from database (enter 0 for unlimited)'
+        ),
+        validators: ['number'],
+    },
     infrastructuralIndicators: {
         label: i18n.t('Infrastructural indicators'),
         configuration: true,

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -387,7 +387,7 @@ const settingsKeyMapping = {
         multiLine: true,
     },
     keyStyle: {
-        label: i18n.t('Style'),
+        label: i18n.t('Style (android)'),
         type: 'dropdown',
         includeEmpty: false,
         userSettingsOverride: true,


### PR DESCRIPTION
Makes some updates in the settings app:
- indicates that `multiOrganisationUnitForms` is displayed up through v41 (not used in new aggregate data entry app)
- adds `KeyTrackedEntityMaxLimit` property
- adds note to indicate that Style property applies to Android app.

(These items are noted on https://dhis2.atlassian.net/browse/DHIS2-19366 which primarily addresses updates for the documentation) 