### PR TITLE
fix: remove v42 app prefix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -134,7 +134,7 @@ const AppWrapper = () => {
         userSettingsNoFallback,
     } = data
 
-    const appsModulePrefix = apiVersion >= 42 ? 'apps/' : 'app:'
+    const appsModulePrefix = apiVersion >= 42 ? 'apps/' : ''
     const startModules = (data.apps.modules || []).map((module) => ({
         id:
             module.defaultAction.substr(0, 3) === '../'


### PR DESCRIPTION
see https://dhis2.atlassian.net/browse/DHIS2-19308

From @netroms for v42: `just set the value to "dhis-web-dashboard" i.e. drop the app:`