### PR TITLE
fix: remove dhis-web- from app names

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,12 +135,15 @@ const AppWrapper = () => {
     } = data
 
     const appsModulePrefix = apiVersion >= 42 ? '' : 'app:'
+    const trimmedAppNameAboveV42 =
+        apiVersion >= 42 ? module.name.replace('dhis-web-', '') : module.name
+
     const startModules = (data.apps.modules || []).map((module) => ({
         id:
             module.defaultAction.substr(0, 3) === '../'
-                ? module.name
-                : appsModulePrefix + module.name,
-        displayName: module.displayName || module.name,
+                ? trimmedAppNameAboveV42
+                : appsModulePrefix + trimmedAppNameAboveV42,
+        displayName: module.displayName || trimmedAppNameAboveV42,
     }))
 
     const flags = (data.flags || []).map((flag) => ({


### PR DESCRIPTION
Removes 'dhis-web-' from app name for v42+ when setting landing page app.