### PR TITLE
fix: add back bing api key [DHIS2-19780]

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -170,6 +170,9 @@ export const categories = {
                 setting: 'keyGoogleMapsApiKey',
             },
             {
+                setting: 'keyBingMapsApiKey',
+            },
+            {
                 setting: 'keyAzureMapsApiKey',
             },
         ],

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -344,6 +344,10 @@ const settingsKeyMapping = {
         label: i18n.t('Google Maps API key'),
         type: 'password',
     },
+    keyBingMapsApiKey: {
+        label: i18n.t('Bing Maps API key'),
+        type: 'password',
+    },
     keyAzureMapsApiKey: {
         label: i18n.t('Azure Maps API key'),
         type: 'password',


### PR DESCRIPTION
adds back keyBingMapsApiKey as it will not be fully deprecated until 2028