### PR TITLE
fix: add true no flag option [DHIS2-18263]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,14 +5,17 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-09-24T08:44:28.347Z\n"
-"PO-Revision-Date: 2025-09-24T08:44:28.348Z\n"
+"POT-Creation-Date: 2025-10-24T11:16:50.846Z\n"
+"PO-Revision-Date: 2025-10-24T11:16:50.846Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
 
 msgid "No flag"
 msgstr "No flag"
+
+msgid "DHIS2"
+msgstr "DHIS2"
 
 msgid "Search settings"
 msgstr "Search settings"
@@ -908,59 +911,3 @@ msgstr "Enable Gist Overview"
 
 msgid "Clean idle jobs after (in milliseconds)"
 msgstr "Clean idle jobs after (in milliseconds)"
-
-msgctxt "Application title"
-msgid "__MANIFEST_APP_TITLE"
-msgstr "System Settings"
-
-msgctxt "Application description"
-msgid "__MANIFEST_APP_DESCRIPTION"
-msgstr ""
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_General"
-msgstr "General"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Analytics"
-msgstr "Analytics"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Server"
-msgstr "Server"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Appearance"
-msgstr "Appearance"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Email"
-msgstr "Email"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Access"
-msgstr "Access"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Calendar"
-msgstr "Calendar"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Data import settings"
-msgstr "Data import settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Synchronization"
-msgstr "Synchronization"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Scheduled job settings"
-msgstr "Scheduled job settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Notification settings"
-msgstr "Notification settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_OAuth2 clients"
-msgstr "OAuth2 clients"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,10 +147,16 @@ const AppWrapper = () => {
         id: flag.key,
         displayName: flag.name,
     }))
-    flags.unshift({
-        id: 'dhis2',
-        displayName: i18n.t('No flag'),
-    })
+    flags.unshift(
+        {
+            id: 'none',
+            displayName: i18n.t('No flag'),
+        },
+        {
+            id: 'dhis2',
+            displayName: i18n.t('DHIS2'),
+        }
+    )
 
     const styles = (data.styles || []).map((style) => ({
         id: style.path,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,6 +135,7 @@ const AppWrapper = () => {
     } = data
 
     const appsModulePrefix = apiVersion >= 42 ? '' : 'app:'
+    const newLoginAppAvailable = apiVersion >= 41
     const startModules = (data.apps.modules || []).map((module) => ({
         id:
             module.defaultAction.substr(0, 3) === '../'
@@ -147,17 +148,18 @@ const AppWrapper = () => {
         id: flag.key,
         displayName: flag.name,
     }))
-    flags.unshift(
-        {
+
+    flags.unshift({
+        id: 'dhis2',
+        displayName: i18n.t('DHIS2'),
+    })
+
+    if (newLoginAppAvailable) {
+        flags.unshift({
             id: 'none',
             displayName: i18n.t('No flag'),
-        },
-        {
-            id: 'dhis2',
-            displayName: i18n.t('DHIS2'),
-        }
-    )
-
+        })
+    }
     const styles = (data.styles || []).map((style) => ({
         id: style.path,
         displayName: style.name,


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-18263

This updates flag options in settings app to label dhis2 flag as `DHIS2` and to add a new "No flag" option that has id of `none`. Note that while `none` does not exist as a hardcoded value on the backend, the backend will accept any string, and since there is no flag of `none`, we can use this as the null option.

Existing implementations would see their "No flag" option become "DHIS2", which is more accurate. This will work in conjunction with the change in the login app https://github.com/dhis2/login-app/pull/55