### PR TITLE
fix: allow user to input rgb values in color picker

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-03T00:13:02.752Z\n"
-"PO-Revision-Date: 2026-03-03T00:13:02.752Z\n"
+"POT-Creation-Date: 2026-03-09T20:16:58.354Z\n"
+"PO-Revision-Date: 2026-03-09T20:16:58.354Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -17,8 +17,8 @@ msgstr "No flag"
 msgid "Search settings"
 msgstr "Search settings"
 
-msgid "Choose a color"
-msgstr "Choose a color"
+msgid "No color selected"
+msgstr "No color selected"
 
 msgid "Remove color"
 msgstr "Remove color"
@@ -295,6 +295,9 @@ msgstr "There was a problem updating settings. Changes have not been saved."
 
 msgid "Period types available in analytics apps"
 msgstr "Period types available in analytics apps"
+
+msgid "This period type is always enabled and cannot be disabled"
+msgstr "This period type is always enabled and cannot be disabled"
 
 msgid "General"
 msgstr "General"
@@ -1022,59 +1025,3 @@ msgstr "Clean idle jobs after (in milliseconds)"
 
 msgid "Use centroids for organisation unit polygons in event analytics"
 msgstr "Use centroids for organisation unit polygons in event analytics"
-
-msgctxt "Application title"
-msgid "__MANIFEST_APP_TITLE"
-msgstr "System Settings"
-
-msgctxt "Application description"
-msgid "__MANIFEST_APP_DESCRIPTION"
-msgstr ""
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_General"
-msgstr "General"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Analytics"
-msgstr "Analytics"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Server"
-msgstr "Server"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Appearance"
-msgstr "Appearance"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Email"
-msgstr "Email"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Access"
-msgstr "Access"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Calendar"
-msgstr "Calendar"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Data import settings"
-msgstr "Data import settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Synchronization"
-msgstr "Synchronization"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Scheduled job settings"
-msgstr "Scheduled job settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_Notification settings"
-msgstr "Notification settings"
-
-msgctxt "Title for shortcut used by command palette"
-msgid "__MANIFEST_SHORTCUT_OAuth2 clients"
-msgstr "OAuth2 clients"

--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -65,10 +65,10 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                         />
                         {!color && (
                             <line
-                                x1="0"
+                                x1="18"
                                 y1="0"
-                                x2="20"
-                                y2="20"
+                                x2="0"
+                                y2="18"
                                 stroke="red"
                                 strokeWidth="1"
                             />

--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -60,7 +60,7 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                         }}
                     />
                     <span style={{ flex: 1, textAlign: 'left', fontSize: 14 }}>
-                        {color || i18n.t('Choose a color')}
+                        {color || i18n.t('No color selected')}
                     </span>
                     {showPicker ? <IconChevronUp16 /> : <IconChevronDown16 />}
                 </button>
@@ -83,7 +83,7 @@ function ColorPicker({ label, onColorPick, color = '' }) {
 
             {showPicker && (
                 <Layer onBackdropClick={() => setShowPicker(false)}>
-                    <Popper placement="right-start" reference={ref}>
+                    <Popper placement="auto" reference={ref}>
                         {/* todo: account for rtl for popper placement */}
                         <div data-test="colors">
                             <SketchPicker

--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -49,22 +49,36 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                     onClick={() => setShowPicker(true)}
                     style={colorButtonStyle}
                 >
-                    <span
+                    <svg
+                        width="20"
+                        height="20"
                         style={{
-                            display: 'inline-block',
-                            width: 20,
-                            height: 20,
                             borderRadius: 2,
                             border: '1px solid rgba(0,0,0,0.2)',
-                            background: color || 'transparent',
+                            display: 'inline-block',
                         }}
-                    />
+                    >
+                        <rect
+                            width="20"
+                            height="20"
+                            fill={color || 'transparent'}
+                        />
+                        {!color && (
+                            <line
+                                x1="0"
+                                y1="0"
+                                x2="20"
+                                y2="20"
+                                stroke="red"
+                                strokeWidth="1"
+                            />
+                        )}
+                    </svg>
                     <span style={{ flex: 1, textAlign: 'left', fontSize: 14 }}>
                         {color || i18n.t('No color selected')}
                     </span>
                     {showPicker ? <IconChevronUp16 /> : <IconChevronDown16 />}
                 </button>
-
                 {color && (
                     <Button
                         type="button"

--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -93,7 +93,6 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                                 onChangeComplete={({ hex }) => {
                                     const nextColor = hex === color ? '' : hex
                                     onColorPick({ color: nextColor })
-                                    setShowPicker(false)
                                 }}
                             />
                         </div>


### PR DESCRIPTION
Fixes part of [DHIS2-21011](https://dhis2.atlassian.net/browse/DHIS2-21011)

-------
 **Description**
This PR allows users to edit the input fields for the hex codes as well as the RGB values without closing the color picker. 

------
**Screenshot**

https://github.com/user-attachments/assets/7b9c9db0-286f-470f-bee4-eec740de6629




[DHIS2-21011]: https://dhis2.atlassian.net/browse/DHIS2-21011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ