### PR TITLE
fix(DHIS2-16608): enforce setting validators and reject invalid saves

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-01-13T22:53:28.645Z\n"
-"PO-Revision-Date: 2026-01-13T22:53:28.645Z\n"
+"POT-Creation-Date: 2026-04-05T10:55:50.124Z\n"
+"PO-Revision-Date: 2026-04-05T10:55:50.124Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -290,6 +290,24 @@ msgstr "There was a problem updating settings. Changes have not been saved."
 msgid "Period types available in analytics apps"
 msgstr "Period types available in analytics apps"
 
+msgid "This field is required"
+msgstr "This field is required"
+
+msgid "This field should be a URL"
+msgstr "This field should be a URL"
+
+msgid "This field should be a number"
+msgstr "This field should be a number"
+
+msgid "This field should be a positive number"
+msgstr "This field should be a positive number"
+
+msgid "This field should be an email"
+msgstr "This field should be an email"
+
+msgid "Please enter a number from {{min}} to {{max}}"
+msgstr "Please enter a number from {{min}} to {{max}}"
+
 msgid "General"
 msgstr "General"
 
@@ -352,21 +370,6 @@ msgstr "Notification settings"
 
 msgid "OAuth2 Clients"
 msgstr "OAuth2 Clients"
-
-msgid "This field is required"
-msgstr "This field is required"
-
-msgid "This field should be a URL"
-msgstr "This field should be a URL"
-
-msgid "This field should be a number"
-msgstr "This field should be a number"
-
-msgid "This field should be a positive number"
-msgstr "This field should be a positive number"
-
-msgid "This field should be an email"
-msgstr "This field should be an email"
 
 msgid "This setting will be overridden by the current user setting: {{settingName}}"
 msgstr "This setting will be overridden by the current user setting: {{settingName}}"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,17 +5,17 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-09T20:16:58.354Z\n"
-"PO-Revision-Date: 2026-03-09T20:16:58.354Z\n"
+"POT-Creation-Date: 2026-04-17T07:03:07.634Z\n"
+"PO-Revision-Date: 2026-04-17T07:03:07.634Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
 
-msgid "No flag"
-msgstr "No flag"
-
 msgid "DHIS2"
 msgstr "DHIS2"
+
+msgid "No flag"
+msgstr "No flag"
 
 msgid "Search settings"
 msgstr "Search settings"
@@ -301,6 +301,24 @@ msgstr "Period types available in analytics apps"
 
 msgid "This period type is always enabled and cannot be disabled"
 msgstr "This period type is always enabled and cannot be disabled"
+
+msgid "This field is required"
+msgstr "This field is required"
+
+msgid "This field should be a URL"
+msgstr "This field should be a URL"
+
+msgid "This field should be a number"
+msgstr "This field should be a number"
+
+msgid "This field should be a positive number"
+msgstr "This field should be a positive number"
+
+msgid "This field should be an email"
+msgstr "This field should be an email"
+
+msgid "Please enter a number from {{min}} to {{max}}"
+msgstr "Please enter a number from {{min}} to {{max}}"
 
 msgid "General"
 msgstr "General"

--- a/src/form-fields/text-field.jsx
+++ b/src/form-fields/text-field.jsx
@@ -13,6 +13,7 @@ class TextFieldComponent extends React.Component {
         helpText: PropTypes.node,
         multiLine: PropTypes.bool,
         value: PropTypes.string,
+        onChange: PropTypes.func,
     }
 
     static defaultProps = {
@@ -37,6 +38,9 @@ class TextFieldComponent extends React.Component {
 
     onChange(e) {
         this.setState({ value: e.target.value })
+        if (this.props.onChange) {
+            this.props.onChange(e)
+        }
     }
 
     render() {

--- a/src/settingValidators.js
+++ b/src/settingValidators.js
@@ -1,0 +1,84 @@
+import i18n from '@dhis2/d2-i18n'
+import { wordToValidatorMap } from 'd2-ui/lib/forms/Validators.js'
+
+const translateValidatorMessage = (validatorMessage) => {
+    switch (validatorMessage) {
+        case 'value_required':
+            return i18n.t('This field is required')
+        case 'value_should_be_a_url':
+            return i18n.t('This field should be a URL')
+        case 'value_should_be_list_of_urls':
+            return i18n.t('This field should contain a list of URLs')
+        case 'value_should_be_a_number':
+            return i18n.t('This field should be a number')
+        case 'value_should_be_a_positive_number':
+            return i18n.t('This field should be a positive number')
+        case 'value_should_be_an_email':
+            return i18n.t('This field should be an email')
+        default:
+            return validatorMessage
+    }
+}
+
+/**
+ * Validators for FormBuilder and for save-time checks. Keeps UI validation and persisted values aligned.
+ */
+export function buildValidatorsForMapping(mapping) {
+    if (!mapping) {
+        return []
+    }
+
+    const validators = []
+
+    if (mapping.validators) {
+        mapping.validators.forEach((name) => {
+            if (wordToValidatorMap.has(name)) {
+                const validator = wordToValidatorMap.get(name)
+                console.log('validator', validator.message, mapping)
+                validators.push({
+                    validator,
+                    message: translateValidatorMessage(validator.message),
+                })
+            }
+        })
+    }
+
+    if (mapping.minValue !== undefined || mapping.maxValue !== undefined) {
+        const min = mapping.minValue
+        const max = mapping.maxValue
+        validators.push({
+            validator: (value) => {
+                if (value === '' || value === null || value === undefined) {
+                    return true
+                }
+                const n = Number(value)
+                if (Number.isNaN(n)) {
+                    return false
+                }
+                if (min !== undefined && n < min) {
+                    return false
+                }
+                if (max !== undefined && n > max) {
+                    return false
+                }
+                return true
+            },
+            message: i18n.t('Please enter a number from {{min}} to {{max}}', {
+                min: min ?? '',
+                max: max ?? '',
+            }),
+        })
+    }
+
+    return validators
+}
+
+export function validateMappingValue(mapping, value) {
+    const validators = buildValidatorsForMapping(mapping)
+    for (const { validator, message } of validators) {
+        if (validator(value) !== true) {
+            return { valid: false, message }
+        }
+    }
+    return { valid: true }
+}

--- a/src/settingValidators.js
+++ b/src/settingValidators.js
@@ -34,7 +34,6 @@ export function buildValidatorsForMapping(mapping) {
         mapping.validators.forEach((name) => {
             if (wordToValidatorMap.has(name)) {
                 const validator = wordToValidatorMap.get(name)
-                console.log('validator', validator.message, mapping)
                 validators.push({
                     validator,
                     message: translateValidatorMessage(validator.message),
@@ -49,7 +48,7 @@ export function buildValidatorsForMapping(mapping) {
         validators.push({
             validator: (value) => {
                 if (value === '' || value === null || value === undefined) {
-                    return true
+                    return false
                 }
                 const n = Number(value)
                 if (Number.isNaN(n)) {

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -9,6 +9,7 @@ import {
 } from './settingsCategories.js'
 import settingsKeyMapping from './settingsKeyMapping.js'
 import settingsStore from './settingsStore.js'
+import { validateMappingValue } from './settingValidators.js'
 
 /* eslint-disable max-params */
 
@@ -74,6 +75,13 @@ settingsActions.saveKey.subscribe((args) => {
     const [key, value, locale] = args.data
     // Can be undefined for some custom sections, i.e. 'keyStopMetadataSync'
     const mapping = settingsKeyMapping[key]
+
+    if (mapping && !locale) {
+        const validation = validateMappingValue(mapping, value)
+        if (!validation.valid) {
+            return
+        }
+    }
 
     getD2().then((d2) => {
         const isLocalisedAppearanceSetting = mapping?.appendLocale && locale

--- a/src/settingsActions.js
+++ b/src/settingsActions.js
@@ -76,7 +76,7 @@ settingsActions.saveKey.subscribe((args) => {
     // Can be undefined for some custom sections, i.e. 'keyStopMetadataSync'
     const mapping = settingsKeyMapping[key]
 
-    if (mapping && !locale) {
+    if (mapping) {
         const validation = validateMappingValue(mapping, value)
         if (!validation.valid) {
             return

--- a/src/settingsFields.component.jsx
+++ b/src/settingsFields.component.jsx
@@ -8,7 +8,6 @@ import {
     Tooltip,
 } from '@dhis2/ui'
 import FormBuilder from 'd2-ui/lib/forms/FormBuilder.component.js'
-import { wordToValidatorMap } from 'd2-ui/lib/forms/Validators.js'
 import PropTypes from 'prop-types'
 import React from 'react'
 import configOptionStore from './configOptionStore.js'
@@ -26,6 +25,7 @@ import { categories } from './settingsCategories.js'
 import classes from './SettingsFields.module.css'
 import settingsKeyMapping from './settingsKeyMapping.js'
 import settingsStore from './settingsStore.js'
+import { buildValidatorsForMapping } from './settingValidators.js'
 import AppTheme from './theme.js'
 
 const styles = {
@@ -54,24 +54,6 @@ const styles = {
         top: -6,
         marginLeft: 16,
     },
-}
-
-const translateValidatorMessage = (validatorMessage) => {
-    switch (validatorMessage) {
-        case 'value_required':
-            return i18n.t('This field is required')
-        case 'value_should_be_a_url':
-            return i18n.t('This field should be a URL')
-        case 'value_should_be_list_of_urls':
-            return i18n.t('This field should contain a list of URLs')
-        case 'value_should_be_a_number':
-            return i18n.t('This field should be a number')
-        case 'value_should_be_a_positive_number':
-            return i18n.t('This field should be a positive number')
-        case 'value_should_be_an_email':
-            return i18n.t('This field should be an email')
-    }
-    return validatorMessage
 }
 
 function wrapUserSettingsOverride({ component, valueLabel }) {
@@ -346,20 +328,7 @@ class SettingsFields extends React.Component {
                 const mapping = settingsKeyMapping[key]
 
                 // Base config, common for all component types
-                const validators = []
-                if (mapping && mapping.validators) {
-                    mapping.validators.forEach((name) => {
-                        if (wordToValidatorMap.has(name)) {
-                            const validator = wordToValidatorMap.get(name)
-                            validators.push({
-                                validator,
-                                message: translateValidatorMessage(
-                                    validator.message
-                                ),
-                            })
-                        }
-                    })
-                }
+                const validators = buildValidatorsForMapping(mapping)
 
                 const fieldBase = {
                     name: key,

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -612,6 +612,7 @@ const settingsKeyMapping = {
         inputType: 'number',
         minValue: 1,
         maxValue: 28,
+        validators: ['positive_number'],
         hideWhen: {
             settingsKey: 'credentialsExpiryAlert',
             settingsValue: 'false',


### PR DESCRIPTION
- Add shared buildValidatorsForMapping with min/max range checks
- Block saveKey when validation fails so bad values are not persisted
- Forward TextField onChange to FormBuilder for correct blur validation
- Add positive_number validator for credentialsExpiresReminderInDays