### PR TITLE
fix: only show theme color setting for v43 and above

### DIFF
--- a/src/settingsCategories.js
+++ b/src/settingsCategories.js
@@ -207,7 +207,7 @@ export const categories = {
             },
             {
                 setting: 'keyCustomColor',
-                // minimumApiVersion: 43
+                minimumApiVersion: 43,
             },
             {
                 setting: 'startModule',


### PR DESCRIPTION
Fixes [DHIS2-21011](https://dhis2.atlassian.net/browse/DHIS2-21011)

----------------
**Description**
- Current bug: The theme color setting appears in v41 and v42, and if someone tries to select a new colour, they get an error. Since this is a new feature available in v43, it fails. 
- Hence, this PR sets the minimum API version to show the theme colour setting for v43+. 

[DHIS2-21011]: https://dhis2.atlassian.net/browse/DHIS2-21011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ