### PR TITLE
fix: allow user to set white theme color

### DIFF
--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -105,6 +105,9 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                                 color={color}
                                 disableAlpha
                                 onChangeComplete={({ hex }) => {
+                                    if (hex !== 'ffffff' && hex === color) {
+                                        return
+                                    }
                                     onColorPick({ color: hex })
                                 }}
                             />

--- a/src/form-fields/color-picker/colorPicker.jsx
+++ b/src/form-fields/color-picker/colorPicker.jsx
@@ -105,8 +105,7 @@ function ColorPicker({ label, onColorPick, color = '' }) {
                                 color={color}
                                 disableAlpha
                                 onChangeComplete={({ hex }) => {
-                                    const nextColor = hex === color ? '' : hex
-                                    onColorPick({ color: nextColor })
+                                    onColorPick({ color: hex })
                                 }}
                             />
                         </div>


### PR DESCRIPTION
Fixes [DHIS2-21307](https://dhis2.atlassian.net/browse/DHIS2-21307)

----------------
**Description**
- When no color is set at the start, the `SketchPicker` initialises with an empty string which `react-color` defaults to white, i.e. "ffffff". The previous logic would compare the white color chosen by the user with what is stored and default to an empty string hence never picking it. 
- This PR removes that logic and relies on the "remove color" button to allow the user to deselect colors. 

-----------------
**Screenshot**

<img width="352" height="90" alt="white-theme-color" src="https://github.com/user-attachments/assets/55b82dc8-59c9-47b9-a5b3-783996d85314" />


[DHIS2-21307]: https://dhis2.atlassian.net/browse/DHIS2-21307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ